### PR TITLE
No need to defend someone else's trademark

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,3 @@ Similar work
   parsing of code and a runtime helper library.  Ideally one or both of
   these projects render this one unnecessary.  The idea of using
   introspection to find "nargout" was borrowed from the ompc project.
-
-Disclaimer
-==========
-MATLAB® is registered trademark of The MathWorks.


### PR DESCRIPTION
Hi, a small request. :-)

You don't need to be defending the Matlab trademark. That is their job, not yours. Your work is not derivative work of Matlab, so there can be no copyright violation, and just mentioning Matlab here does not hurt its trademark, so it's unlikely that the Mathworks lawyers will come after you insisting that you defend their trademark.

As it is, defending someone else's trademark just sounds like kowtowing. You don't owe the Mathworks anything. So don't defend their trademark.
