### PR TITLE
Raise AttributeErrors in __getattr__.

### DIFF
--- a/oct2py/session.py
+++ b/oct2py/session.py
@@ -397,7 +397,7 @@ class Oct2Py(object):
             raise Oct2PyError(
                 "Attributes don't look like this: {0}".format(attr))
         if attr.startswith('_'):
-            raise Oct2PyError(
+            raise AttributeError(
                 "Octave commands do not start with _: {0}".format(attr))
         # print_ -> print
         if attr[-1] == "_":


### PR DESCRIPTION
This fixes help(Oct2Py()), tab completion in IPython is broken however
since it tries to call `trait_names` without checking for its existence
first, leading to an annoying `Oct2PyError` about this function not
existing.
