### PR TITLE
Enable long_field_names for savemat integration

### DIFF
--- a/oct2py/matwrite.py
+++ b/oct2py/matwrite.py
@@ -66,7 +66,7 @@ class MatWrite(object):
         if not os.path.exists(self.in_file):
             self.in_file = create_file()
         try:
-            savemat(self.in_file, data, appendmat=False, oned_as='row')
+            savemat(self.in_file, data, appendmat=False, oned_as='row', long_field_names=True)
         except KeyError:  # pragma: no cover
             raise Exception('could not save mat file')
         load_line = 'load {} "{}"'.format(self.in_file,


### PR DESCRIPTION
Long_field_names was exposed in scipy by [this thread](http://mail.scipy.org/pipermail/scipy-dev/2008-December/010511.html), enabling the writing of MLv7 files.

Works for me at least.

(May need to be extended to be version sensitive)
