### PR TITLE
source key is deprecated in publish_display_data

### DIFF
--- a/oct2py/ipython/octavemagic.py
+++ b/oct2py/ipython/octavemagic.py
@@ -364,7 +364,9 @@ class OctaveMagics(Magics):
                 self.shell.push({output: self._oct.get(output)})
 
         for source, data in display_data:
-            self._publish_display_data(source, data)
+            # source is deprecated in IPython 3.0.
+            # specify with kwarg for backward compatibility.
+            self._publish_display_data(source=source, data=data)
 
         if return_output:
             try:


### PR DESCRIPTION
in IPython 3.0

It is kept as a kwarg to preserve backward compatibility.
