### PR TITLE
Closing pty sessions properly

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -975,6 +975,12 @@ class _Session(object):
         except Exception as e:  # pragma: no cover
             self.logger.debug(e)
 
+        #Clean open pty terminals to avoid leaving to much of them opened
+        try:
+            os.close(self.wfid)
+        except Exception as e:  # pragma: no cover
+            self.logger.debug(e)
+
         self.reader.wants_abort = True
         self.proc = None
 


### PR DESCRIPTION
Pty sessions were left open and problems can arise when a server has been up for a long time. This fixes that.