### PR TITLE
Prevents interactive prompt when importing symbolic package

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -861,7 +861,7 @@ class _Session(object):
             elif '\x1b[C' in line or line.strip() == '>>':
                 line = ''
 
-            elif line.endswith('> '):
+            elif line.endswith('> ') and not line.endswith('>>> '):
                 self.interact(line)
 
             elif line.startswith(' ') and line.strip() == '^':


### PR DESCRIPTION
This pull request prevents loading the symbolic package from triggering the interactive mode. This is a proposed fix for issue #91 