### PR TITLE
Handle dynamic classes

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -557,12 +557,11 @@ class Oct2Py(object):
             obj = _make_octave_class(self, name)
         else:
             obj = _make_octave_command(self, name)
-            # bind to the instance with a weakref (to avoid circular
-            # references
+            # bind to the instance.
             if PY2:
-                obj = types.MethodType(obj, weakref.ref(self), Oct2Py)
+                obj = types.MethodType(obj, self, Oct2Py)
             else:
-                obj = types.MethodType(obj, weakref.ref(self))
+                obj = types.MethodType(obj, self)
 
         # !!! attr, *not* name, because we might have python keyword name!
         setattr(self, attr, obj)

--- a/oct2py/dynamic.py
+++ b/oct2py/dynamic.py
@@ -1,0 +1,171 @@
+import weakref
+import types
+
+from oct2py.utils import get_nout
+from oct2py.compat import PY2
+
+
+class OctaveFunction(object):
+
+    def __init__(self, parent_weakref, name):
+        """An object representing an Octave function.
+
+        Methods are dynamically bound to instances of Octave objects and
+        represent a callable function in the Octave session.
+
+        Parameters
+        ----------
+        parent_weakref: Oct2Py instance weak reference
+            A weak reference to the parent (Oct2Py instance) to which the
+                OctaveFunction is being bound.
+        name: str
+            The name of the Octave function this represents
+        """
+        self.name = name
+        self._ref = parent_weakref
+
+    def __call__(self, parent, *inputs, **kwargs):
+        """Call the function with the supplied arguments in the Octave session.
+        """
+        kwargs['nout'] = kwargs.get('nout', get_nout())
+        kwargs['verbose'] = kwargs.get('verbose', False)
+        return self._ref()._call(self.name, *inputs, **kwargs)
+
+    def __repr__(self):
+        return '"%s" Octave function' % self.name
+
+    def __getattribute__(self, name):
+        if name == '__doc__':
+            return self._ref()._get_doc(self.name)
+        return object.__getattribute__(self, name)
+
+
+class OctaveClass(object):
+    """A wrapper for an Octave Class.
+    """
+
+    def __init__(self, *inputs, **kwargs):
+        """Create an octave class with the supplied arguments.
+        """
+        name = self._name
+        self._var = '%s_%s' % (name, id(self))
+        kwargs['nout'] = 1
+        kwargs['verbose'] = kwargs.get('verbose', False)
+        kwargs['_is_class'] = True
+        kwargs['_class_var'] = self._var
+        self._ref()._call(name, *inputs, **kwargs)
+        self._create_methods()
+
+    def _create_methods(self):
+        """Create the dynamic methods.
+        """
+        for (name, cls) in self._methods.items():
+            instance = cls(self._ref, self._var, self._name, name)
+            instance.__name__ = name
+            # bind to the instance.
+            if PY2:
+                method = types.MethodType(instance, self, OctaveClass)
+            else:
+                method = types.MethodType(instance, self)
+            setattr(self, name, method)
+
+    def __repr__(self):
+        return '"%s" Octave class instance "%s"' % (self._name, self._var)
+
+    def __getattribute__(self, name):
+        if name == '__doc__':
+            return self._ref()._get_doc(self._name)
+        if name.startswith('_'):
+            return object.__getattribute__(self, name)
+        if name in self._attrs:
+            lookup = 'ans = get(%s, "%s");' % (self._var, name)
+            return self._ref().eval(lookup)
+        return object.__getattribute__(self, name)
+
+
+class OctaveClassMethod(object):
+    """A wrapper for an Octave class method.
+    """
+
+    def __init__(self, oct2py_weakref, var, obj_name, name):
+        """An object representing an Octave class method.
+
+        Methods are dynamically bound to instances of Octave objects and
+        represent a callable function in the Octave session.
+
+        Parameters
+        ----------
+        oct2py_weakref: Oct2Py instance weak reference
+            A weak reference to the parent (Oct2Py instance) to which the
+                OctaveClassMethod is being bound
+        var: str
+            The variable name of the parent instance.
+        obj_name: str
+            The name of the object on which the method is contained.
+        name: str
+            The name of the method this represents
+        """
+        self.name = name
+        self._ref = oct2py_weakref
+        self.var = var
+        self._obj_name = obj_name
+
+    def __repr__(self):
+        return '"%s" method of "%s" object' % (self.name, self.var)
+
+    def __call__(self, instance, *inputs, **kwargs):
+        """Call the function with the variable name and the supplied arguments
+         in the Octave session.
+        """
+        kwargs['nout'] = kwargs.get('nout', get_nout())
+        kwargs['verbose'] = kwargs.get('verbose', False)
+        kwargs['_is_class_lookup'] = True
+        kwargs['_class_var'] = self.var
+        return self._ref()._call(self.name, *inputs, **kwargs)
+
+    def __getattribute__(self, name):
+        if name == '__doc__':
+            doc_name = '@%s/%s' % (self._obj_name, self.name)
+            doc = self._ref()._get_doc(doc_name)
+            return doc or self._ref()._get_doc(self.name)
+        return object.__getattribute__(self, name)
+
+
+def _make_octave_command(parent, name):
+    """Create a wrapper to an Octave procedure or object
+
+    Adapted from the python-matlab-bridge project
+    """
+    custom = type(name, (OctaveFunction,), {})
+    method_instance = custom(weakref.ref(parent), name)
+    method_instance.__name__ = name
+    return method_instance
+
+
+def _make_octave_class(parent, name):
+    """Make an Octave class for a given class name"""
+    attrs = parent.eval('ans = fieldnames(%s);' % name)
+    methods = parent.eval('ans = methods(%s);' % name)
+    values = dict()
+    for attr in attrs:
+        values[attr] = 'dynamic_attribute'
+
+    def create_dynamic_method(method):
+        def dynamic_method(self):
+            pass
+        dynamic_method.__doc__ = 'Dynamic method of "%s".' % (name)
+        dynamic_method.__name__ = method
+        return dynamic_method
+
+    values['_methods'] = dict()
+    for method in methods:
+        values['_methods'][method] = type(method, (OctaveClassMethod,), {})
+        values[method] = create_dynamic_method(method)
+
+    values['_ref'] = weakref.ref(parent)
+    values['_attrs'] = attrs
+    values['_name'] = name
+
+    custom = type(name, (OctaveClass,), values)
+    custom.__module__ = 'oct2py.dynamic'
+    return custom

--- a/oct2py/tests/@polynomial/display.m
+++ b/oct2py/tests/@polynomial/display.m
@@ -1,0 +1,32 @@
+function display (p)
+  a = p.poly;
+  first = true;
+  fprintf ("%s =", inputname (1));
+  for i = 1 : length (a);
+    if (a(i) != 0)
+      if (first)
+        first = false;
+      elseif (a(i) > 0)
+        fprintf (" +");
+      endif
+      if (a(i) < 0)
+        fprintf (" -");
+      endif
+      if (i == 1)
+        fprintf (" %g", abs (a(i)));
+      elseif (abs(a(i)) != 1)
+        fprintf (" %g *", abs (a(i)));
+      endif
+      if (i > 1)
+        fprintf (" X");
+      endif
+      if (i > 2)
+        fprintf (" ^ %d", i - 1);
+      endif
+    endif
+  endfor
+  if (first)
+    fprintf (" 0");
+  endif
+  fprintf ("\n");
+endfunction

--- a/oct2py/tests/@polynomial/display.m
+++ b/oct2py/tests/@polynomial/display.m
@@ -1,4 +1,6 @@
 function display (p)
+  %% Display a polynomial object
+
   a = p.poly;
   first = true;
   fprintf ("%s =", inputname (1));

--- a/oct2py/tests/@polynomial/get.m
+++ b/oct2py/tests/@polynomial/get.m
@@ -1,0 +1,18 @@
+function s = get (p, f)
+  if (nargin == 1)
+    s.poly = p.poly;
+  elseif (nargin == 2)
+    if (ischar (f))
+      switch (f)
+        case "poly"
+          s = p.poly;
+        otherwise
+          error ("get: invalid property %s", f);
+      endswitch
+    else
+      error ("get: expecting the property to be a string");
+    endif
+  else
+    print_usage ();
+  endif
+endfunction

--- a/oct2py/tests/@polynomial/polynomial.m
+++ b/oct2py/tests/@polynomial/polynomial.m
@@ -1,0 +1,30 @@
+## -*- texinfo -*-
+## @deftypefn  {Function File} {} polynomial ()
+## @deftypefnx {Function File} {} polynomial (@var{a})
+## Create a polynomial object representing the polynomial
+##
+## @example
+## a0 + a1 * x + a2 * x^2 + @dots{} + an * x^n
+## @end example
+##
+## @noindent
+## from a vector of coefficients [a0 a1 a2 @dots{} an].
+## @end deftypefn
+
+function p = polynomial (a)
+  if (nargin == 0)
+    p.poly = [0];
+    p = class (p, "polynomial");
+  elseif (nargin == 1)
+    if (strcmp (class (a), "polynomial"))
+      p = a;
+    elseif (isvector (a) && isreal (a))
+      p.poly = a(:).';
+      p = class (p, "polynomial");
+    else
+      error ("polynomial: expecting real vector");
+    endif
+  else
+    print_usage ();
+  endif
+endfunction

--- a/oct2py/tests/@polynomial/set.m
+++ b/oct2py/tests/@polynomial/set.m
@@ -1,0 +1,20 @@
+function s = set (p, varargin)
+  s = p;
+  if (length (varargin) < 2 || rem (length (varargin), 2) != 0)
+    error ("set: expecting property/value pairs");
+  endif
+  while (length (varargin) > 1)
+    prop = varargin{1};
+    val = varargin{2};
+    varargin(1:2) = [];
+    if (ischar (prop) && strcmp (prop, "poly"))
+      if (isvector (val) && isreal (val))
+        s.poly = val(:).';
+      else
+        error ("set: expecting the value to be a real vector");
+      endif
+    else
+      error ("set: invalid property of polynomial class");
+    endif
+  endwhile
+endfunction

--- a/oct2py/tests/test_misc.py
+++ b/oct2py/tests/test_misc.py
@@ -226,6 +226,7 @@ class MiscTests(test.TestCase):
     b = 3
     b + 1""")
         text = hdlr.stream.getvalue().strip()
+        self.oc.logger.removeHandler(hdlr)
         assert ans == 4
         lines = text.splitlines()
         assert lines[-1] == 'ans =  4'

--- a/oct2py/tests/test_usage.py
+++ b/oct2py/tests/test_usage.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 import os
+import logging
 import pickle
 import tempfile
 
@@ -10,6 +11,7 @@ import numpy.testing as test
 
 from oct2py import Oct2Py, Oct2PyError
 from oct2py.utils import Struct
+from oct2py.compat import StringIO
 
 
 class BasicUsageTest(test.TestCase):
@@ -148,3 +150,20 @@ class BasicUsageTest(test.TestCase):
         plot_dir = tempfile.mkdtemp().replace('\\', '/')
         self.oc.plot([1, 2, 3], linewidth=3, plot_dir=plot_dir)
         assert self.oc.extract_figures(plot_dir)
+
+    def test_octave_class(self):
+        polynomial = self.oc.polynomial
+        p0 = polynomial([1, 2, 3])
+        test.assert_equal(p0.poly, [[1, 2, 3]])
+
+        p1 = polynomial([0, 1, 2])
+        sobj = StringIO()
+        hdlr = logging.StreamHandler(sobj)
+        hdlr.setLevel(logging.DEBUG)
+        self.oc.logger.addHandler(hdlr)
+        self.oc.logger.setLevel(logging.DEBUG)
+        p1.display(verbose=True)
+        text = hdlr.stream.getvalue().strip()
+        self.oc.logger.removeHandler(hdlr)
+        assert str(id(p1)) in text
+        assert 'X + 2 * X ^ 2' in text


### PR DESCRIPTION
Fixes #80.  Also cleans up dynamic method handling and makes sure all methods have a nice `repr` and `help`.

Example:

```python
from oct2py import octave
p = octave.polynomial([1,2,3])
p.display(verbose=True)  # prints the nice display of the polynomial
p.poly  # prints the array
```