### PR TITLE
.FIX For Python 3.6 only one value is unpacked on function return

### DIFF
--- a/oct2py/utils.py
+++ b/oct2py/utils.py
@@ -8,7 +8,7 @@
 import inspect
 import dis
 from oct2py.compat import PY2
-
+import sys
 
 def get_nout():
     """
@@ -27,10 +27,16 @@ def get_nout():
     # nout is two frames back
     frame = frame.f_back.f_back
     bytecode = frame.f_code.co_code
-    instruction = bytecode[frame.f_lasti + 3]
+    if(sys.version_info > (3,5)):
+        instruction = bytecode[frame.f_lasti + 2]
+    else:
+        instruction = bytecode[frame.f_lasti + 3]
     instruction = ord(instruction) if PY2 else instruction
     if instruction == dis.opmap['UNPACK_SEQUENCE']:
-        howmany = bytecode[frame.f_lasti + 4]
+        if(sys.version_info > (3,5)):
+            howmany = bytecode[frame.f_lasti + 3]
+        else:
+            howmany = bytecode[frame.f_lasti + 4]
         howmany = ord(howmany) if PY2 else howmany
         return howmany
     elif instruction in [dis.opmap['POP_TOP'], dis.opmap['PRINT_EXPR']]:


### PR DESCRIPTION
Python 3.6 frames are built up differently. With the current implementation, Python 3.6 returns only one value even if multiple values are returned e.g.

/home/ossy/development/git-repositories/Crapicip/ContextEnvironment.py in getWriteCost(self)
    181             tListOfSICs.append(1)
    182             print("Computing steiner tree for SICs ", tListOfSICs)
--> 183           **cost_pspiel, edges_pspiel, steiner_pspiel**= self.configuration.octave.sfo_pspiel_get_cost(tListOfSICs, self.configuration.symWeightAdjM);
    184             self.writeCost = cost_pspiel
    185 

**TypeError: 'numpy.float64' object is not iterable**

Kind regards,
Manuel