### PR TITLE
install_requires incorporating requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ License :: OSI Approved :: MIT License
 Operating System :: OS Independent
 Programming Language :: Python
 Programming Language :: Python :: 2.7
-Programming Language :: Python :: 3.3
-Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3
 Topic :: Scientific/Engineering
 Topic :: Software Development
 """
@@ -62,6 +61,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     classifiers=list(filter(None, CLASSIFIERS.split('\n'))),
     requires=REQUIRES,
-    install_requires=INSTALL_REQUIRES,
+    install_requires=INSTALL_REQUIRES + REQUIRES,
     extras_require=EXTRAS_REQUIRE
 )


### PR DESCRIPTION
I didn't see `requires` in `setuptools.setup()` docs. And so then I get errors on new Python installs where I don't have SciPy installed when using Oct2Py.

Can `install_requires` incorporate `requires`?

The only line I changed was:

    install_requires=INSTALL_REQUIRES + REQUIRES,

and removing line

    requires=REQUIRES,