### PR TITLE
FIX: no-OUT-args check was destroying original error location and was hiding similar user-errors 

### DIFF
--- a/oct2py/_pyeval.m
+++ b/oct2py/_pyeval.m
@@ -66,7 +66,15 @@ try
       end
 
     else
+      try
         [result{1:req.nout}] = feval(req.func_name);
+      catch ME
+          rethrow(ME);
+        if (strcmp(ME.message, 'element number 1 undefined in return list') != 1 ||
+            length(ME.stack) != 1)
+          rethrow(ME);
+        end
+      end
     end
 
     if req.store_as

--- a/oct2py/_pyeval.m
+++ b/oct2py/_pyeval.m
@@ -56,7 +56,8 @@ try
       try
         [result{1:req.nout}] = feval(req.func_name, req.func_args{:});
       catch ME
-        if (strcmp(ME.message, 'element number 1 undefined in return list') != 1)
+        if (strcmp(ME.message, 'element number 1 undefined in return list') != 1 ||
+            length(ME.stack) != 1)
           rethrow(ME);
         else
           result = get_ans(sentinel);

--- a/oct2py/_pyeval.m
+++ b/oct2py/_pyeval.m
@@ -57,7 +57,7 @@ try
         [result{1:req.nout}] = feval(req.func_name, req.func_args{:});
       catch ME
         if (strcmp(ME.message, 'element number 1 undefined in return list') != 1)
-          error(ME);
+          rethrow(ME);
         else
           result = get_ans(sentinel);
         end

--- a/oct2py/tests/pyeval_like_error0.m
+++ b/oct2py/tests/pyeval_like_error0.m
@@ -1,0 +1,3 @@
+function pyeval_like_error1()
+    error('element number 1 undefined in return list')
+end 

--- a/oct2py/tests/pyeval_like_error1.m
+++ b/oct2py/tests/pyeval_like_error1.m
@@ -1,0 +1,3 @@
+function x = pyeval_like_error2()
+    error('element number 1 undefined in return list')
+end 

--- a/oct2py/tests/pyeval_like_error2.m
+++ b/oct2py/tests/pyeval_like_error2.m
@@ -1,0 +1,3 @@
+function x = pyeval_like_error3(y)
+    error('element number 1 undefined in return list')
+end 

--- a/oct2py/tests/pyeval_like_error3.m
+++ b/oct2py/tests/pyeval_like_error3.m
@@ -1,0 +1,3 @@
+function pyeval_like_error4(y)
+    error('element number 1 undefined in return list')
+end 

--- a/oct2py/tests/test_usage.py
+++ b/oct2py/tests/test_usage.py
@@ -80,7 +80,7 @@ class TestUsage:
         with pytest.raises(Oct2PyError):
             self.oc.__getattr__('_foo')
         with pytest.raises(Oct2PyError):
-            self.oc.__getattr__('foo\W')
+            self.oc.__getattr__('foo\\W')
 
     def test_open_close(self):
         """Test opening and closing the Octave session
@@ -301,6 +301,35 @@ class TestUsage:
             "Octave evaluation error:\nerror: "
             "'b' undefined near line 2 column 3\nerror: called from:\n    script_error at line 2, column 2"
         )
+
+    @pytest.mark.parametrize("fn", [
+        "pyeval_like_error%s" % i for i in range(4)
+    ])
+    def test_script_error_like_my_pyeval(self, fn):
+        exp = "element number 1 undefined in return list"
+        here = os.path.dirname(__file__)
+        with pytest.raises(Oct2PyError, match=exp):
+            self.oc.source(os.path.join(here, "%s.m" % fn))
+
+    def test_script_error_like_my_pyeval0(self):
+        exp = "element number 1 undefined in return list"
+        with pytest.raises(Oct2PyError, match=exp):
+            self.oc.pyeval_like_error0()
+
+    def test_script_error_like_my_pyeval1(self):
+        exp = "element number 1 undefined in return list"
+        with pytest.raises(Oct2PyError, match=exp):
+            self.oc.pyeval_like_error1()
+
+    def test_script_error_like_my_pyeval2(self):
+        exp = "element number 1 undefined in return list"
+        with pytest.raises(Oct2PyError, match=exp):
+            self.oc.pyeval_like_error2(1)
+
+    def test_script_error_like_my_pyeval3(self):
+        exp = "element number 1 undefined in return list"
+        with pytest.raises(Oct2PyError, match=exp):
+            self.oc.pyeval_like_error3(1)
 
     def test_pkg_load(self):
         self.oc.eval('pkg load signal')

--- a/oct2py/tests/test_usage.py
+++ b/oct2py/tests/test_usage.py
@@ -297,7 +297,10 @@ class TestUsage:
         with pytest.raises(Oct2PyError) as exec_info:
             self.oc.source(os.path.join(here, 'script_error.m'))
         msg = str(exec_info.value)
-        assert msg == "Octave evaluation error:\nerror: 'b' undefined near line 2 column 3"
+        assert msg == (
+            "Octave evaluation error:\nerror: "
+            "'b' undefined near line 2 column 3\nerror: called from:\n    script_error at line 2, column 2"
+        )
 
     def test_pkg_load(self):
         self.oc.eval('pkg load signal')


### PR DESCRIPTION
As hinted in in my recent comment #115.
i'm losing the location-context, filename & line-number (lineno) of user's code errors from the matlab-side.

I traced the error to the matlab statement used to re-raise any errors caught.
The proper way is to `rethrow()` errors, not to raise them as new errors.
Did it work in the older versions (from mine, Octave-5.2.0 & oct2py 5.0.4)?