### PR TITLE
Update for latest octave_kernel

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -9,6 +9,7 @@ jobs:
   check_release:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         group: [check_release, link_check]
     steps:

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,7 +1,7 @@
 name: Check Release
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
     branches: ["*"]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,9 @@ name: oct2py
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     # Run weekly
     # * is a special character in YAML so you have to quote this string

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
          make release_prep
     - name: Generate coverage report
       run: |
-        make cover
+        xvfb-run --auto-servernum make cover
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         make install
     - name: Run test
       run: |
-        make test
+        xvfb-run --auto-servernum make test
     - name: Generate Docs
       run: |
         make docs

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ clean:
 
 test: clean
 	pip install -q pytest
-	export PYTHONWARNINGS="all"; py.test
+	export PYTHONWARNINGS="all"; py.test --doctest-modules
 	make clean
 	jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --stdout example/octavemagic_extension.ipynb > /dev/null;
 
 cover: clean
 	pip install -q pytest codecov pytest-cov
-	py.test -l --cov-report html --cov-report=xml --cov=${NAME}
+	py.test --doctest-modules -l --cov-report html --cov-report=xml --cov=${NAME}
 
 release_prep: clean
 	pip install -q wheel twine

--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,17 @@ clean:
 	rm -rf dist
 	find . -name "*.pyc" -o -name "*.py,cover"| xargs rm -f
 	python -c $(KILL_PROC); true
-	killall -9 py.test; true
+	killall -9 pytest; true
 
 test: clean
 	pip install -q pytest
-	export PYTHONWARNINGS="all"; py.test --doctest-modules
+	export PYTHONWARNINGS="all"; pytest --doctest-modules
 	make clean
 	jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --stdout example/octavemagic_extension.ipynb > /dev/null;
 
 cover: clean
 	pip install -q pytest codecov pytest-cov
-	py.test --doctest-modules -l --cov-report html --cov-report=xml --cov=${NAME}
+	pytest --doctest-modules -l --cov-report html --cov-report=xml --cov=${NAME}
 
 release_prep: clean
 	pip install -q wheel twine

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Installation
 ------------
 You must have GNU Octave installed and in your ``PATH`` environment variable.
 Alternatively, you can set an ``OCTAVE_EXECUTABLE`` or ``OCTAVE`` environment
-variable that points to ``octave-cli`` executable itself.
+variable that points to ``octave`` executable itself.
 
 You must have the Numpy and Scipy libraries for Python installed.
 See the installation instructions_ for more details.

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Oct2Py: Python to GNU Octave Bridge
 .. image:: https://badge.fury.io/py/oct2py.png/
     :target: http://badge.fury.io/py/oct2py
 
-.. image:: https://codecov.io/github/blink1073/oct2py/coverage.svg?branch=master
-  :target: https://codecov.io/github/blink1073/oct2py?branch=master
+.. image:: https://codecov.io/github/blink1073/oct2py/coverage.svg?branch=main
+  :target: https://codecov.io/github/blink1073/oct2py?branch=main
 
 .. image:: http://pepy.tech/badge/oct2py
    :target: http://pepy.tech/project/oct2py
@@ -75,7 +75,7 @@ Features
 - Optional timeout command parameter to prevent runaway Octave sessions.
 
 
-.. _OctaveMagic: https://nbviewer.jupyter.org/github/blink1073/oct2py/blob/master/example/octavemagic_extension.ipynb?create=1
+.. _OctaveMagic: https://nbviewer.jupyter.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1
 
 
 Installation
@@ -111,4 +111,4 @@ For version information, see the Changelog_.
 
 .. _online: https://oct2py.readthedocs.io/en/latest/
 
-.. _Changelog: https://github.com/blink1073/oct2py/blob/master/CHANGELOG.md
+.. _Changelog: https://github.com/blink1073/oct2py/blob/main/CHANGELOG.md

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -7,7 +7,7 @@ OctaveMagic
 Oct2Py provides a plugin for IPython to bring Octave to the IPython prompt or the
 IPython Notebook_.
 
-.. _Notebook: http://nbviewer.jupyter.org/github/blink1073/oct2py/blob/master/example/octavemagic_extension.ipynb?create=1
+.. _Notebook: http://nbviewer.jupyter.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1
 
 
 M-File Examples

--- a/docs/source/info.rst
+++ b/docs/source/info.rst
@@ -128,16 +128,15 @@ timeout.
 
 Graphics Toolkit
 ================
-Oct2Py uses the `gnuplot` graphics toolkit by default.  Fltk has been known
-not to work on some systems.  To change toolkits:
+Oct2Py uses the `qt` graphics toolkit by default.  To change toolkits:
 
 .. code-block:: python
 
     >>> from oct2py import octave
     >>> octave.available_graphics_toolkits()   # doctest: +SKIP
-    ['fltk', 'gnuplot']
-    >>> octave.graphics_toolkit('fltk')  # doctest: +SKIP
-    'fltk'
+    ['qt', 'gnuplot']
+    >>> octave.graphics_toolkit('gnuplot')  # doctest: +SKIP
+    'gnuplot'
 
 Context Manager
 ===============

--- a/docs/source/info.rst
+++ b/docs/source/info.rst
@@ -205,7 +205,7 @@ IPython Notebook
 Oct2Py provides OctaveMagic_ for IPython, including inline plotting in
 notebooks.  This requires IPython >= 1.0.0.
 
-.. _OctaveMagic: http://nbviewer.jupyter.org/github/blink1073/oct2py/blob/master/example/octavemagic_extension.ipynb?create=1
+.. _OctaveMagic: http://nbviewer.jupyter.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1
 
 
 

--- a/example/octavemagic_extension.ipynb
+++ b/example/octavemagic_extension.ipynb
@@ -55,9 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -79,9 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -114,9 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%octave -i x -o U,S,V\n",
@@ -126,9 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -162,9 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -342,7 +332,6 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [
@@ -369,9 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -409,9 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -8724,41 +8709,12 @@
     "figure\n",
     "imshow(rand(200,200))"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Plots can be drawn inline (default) or bring up the Octave plotting GUI by using the -g (or --gui) flag: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "%%octave -g\n",
-    "plot([1,2,3])\n",
-    "# brings up an Octave plotting GUI"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -8772,7 +8728,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/oct2py/ipython/octavemagic.py
+++ b/oct2py/ipython/octavemagic.py
@@ -150,10 +150,6 @@ class OctaveMagics(Magics):
         help='Plot format (png, svg or jpg).'
     )
     @argument(
-        '-g', '--gui', action='store_true', default=False,
-        help='Show a gui for plots.  Default is False'
-    )
-    @argument(
         '-w', '--width', type=int, action='store',
         help='The width of the plot in pixels'
     )
@@ -250,10 +246,8 @@ class OctaveMagics(Magics):
         if args.size is not None:
             width, height = [int(s) for s in args.size.split(',')]
 
-        plot_dir = None
-        if args.gui is not None:
-            plot_dir_obj = tempfile.TemporaryDirectory()
-            plot_dir = plot_dir_obj.name
+        plot_dir_obj = tempfile.TemporaryDirectory()
+        plot_dir = plot_dir_obj.name
 
         temp_dir = args.temp_dir
         if temp_dir is not None and not os.path.isdir(temp_dir):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,4 @@ default = 0
 
 [tool.pytest.ini_options]
 testpaths = "oct2py"
-addopts = "--doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.7
 install_requires =
     numpy >=1.12
     scipy >=0.17
-    octave_kernel >= 0.31.0
+    octave_kernel >= 0.34.0
 
 [options.extras_require]
 test = pytest;pandas;nbconvert


### PR DESCRIPTION
- Use `qt` backend by default
- Use `octave` executable by default

Fixes #183 