### PR TITLE
add _print_doc

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -626,6 +626,22 @@ class Oct2Py(object):
         """Handle a stdin request from the session."""
         return input(line.replace(STDIN_PROMPT, ''))
 
+    def _print_doc(self, name):
+        """
+        Print the documentation of an Octave procedure or object.
+
+        Parameters
+        ----------
+        name : str
+            Function name to search for.
+
+        Returns
+        -------
+        out : None
+
+        """
+        print(self._get_doc(name))
+
     def _get_doc(self, name):
         """
         Get the documentation of an Octave procedure or object.


### PR DESCRIPTION
`_get_doc()` is ugly with `\n`. Using `oc.func__name??` on IPython is better. But, sometimes, we just want to print and not using magic. `print(_get_doc())` will do. Yet, `_print_doc()` will make it straightforward.