### PR TITLE
Fix column vector

### DIFF
--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -222,8 +222,11 @@ class Cell(np.ndarray):
     [1.0, 1.0]
     """
     def __new__(cls, value, session=None):
-        """Create a cell array from a value and optional Octave session."""
-        # Use atleast_2d to preserve equality between Octave size() and Python numpy.shape()
+        """Create a cell array from a value and optional Octave session.
+        
+        See: https://github.com/yasirroni/PyMatType/pymattype/matlab_like.py
+        """
+        # Use atleast_2d to preserve Octave size()
         value = np.atleast_2d(np.asarray(value, dtype=object))
 
         if not session:

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -220,10 +220,9 @@ class Cell(np.ndarray):
     def __new__(cls, value, session=None):
         """Create a cell array from a value and optional Octave session."""
         value = np.asarray(value, dtype=object)
-        # Squeeze the last element if it is 1
-        if (value.shape[value.ndim - 1] == 1):
-            value = value.squeeze(axis=value.ndim - 1)
-        value = np.atleast_1d(value)
+
+        # Use atleast_2d to preserve equality between Octave size() and Python numpy.shape()
+        value = np.atleast_2d(value)
 
         if not session:
             return value.view(cls)

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -397,15 +397,16 @@ def _encode(data, convert_to_float):
     # Extract and encode data from object-like arrays.
     if data.dtype.kind in 'OV':
         out = np.empty(data.size, dtype=data.dtype)
-        if data.size > 1:
-            for (i, item) in enumerate(data.ravel()):
-                if data.dtype.names:
+        if data.size == 1:
+            out[0] = _encode(data[0], ctf)
+        else:
+            if data.dtype.names:
+                for (i, item) in enumerate(data.ravel()):
                     for name in data.dtype.names:
                         out[i][name] = _encode(item[name], ctf)
-                else:
+            else:
+                for (i, item) in enumerate(data.ravel()):
                     out[i] = _encode(item, ctf)
-        else:
-            out[0] = _encode(data[0], ctf)
         return out.reshape(data.shape)
 
     # Complex 128 is the highest supported by savemat.

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -49,7 +49,11 @@ def read_file(path, session=None):
 def write_file(obj, path, oned_as='row', convert_to_float=True):
     """Save a Python object to an Octave file on the given path.
     """
+    # print(obj)
+    # print(type(obj))
     data = _encode(obj, convert_to_float)
+    # print(data)
+    # print(type(data))
     try:
         # scipy.io.savemat is not thread-save.
         # See https://github.com/scipy/scipy/issues/7260
@@ -393,12 +397,15 @@ def _encode(data, convert_to_float):
     # Extract and encode data from object-like arrays.
     if data.dtype.kind in 'OV':
         out = np.empty(data.size, dtype=data.dtype)
-        for (i, item) in enumerate(data.ravel()):
-            if data.dtype.names:
-                for name in data.dtype.names:
-                    out[i][name] = _encode(item[name], ctf)
-            else:
-                out[i] = _encode(item, ctf)
+        if data.size > 1:
+            for (i, item) in enumerate(data.ravel()):
+                if data.dtype.names:
+                    for name in data.dtype.names:
+                        out[i][name] = _encode(item[name], ctf)
+                else:
+                    out[i] = _encode(item, ctf)
+        else:
+            out[0] = _encode(data[0], ctf)
         return out.reshape(data.shape)
 
     # Complex 128 is the highest supported by savemat.

--- a/oct2py/tests/test_conversions.py
+++ b/oct2py/tests/test_conversions.py
@@ -129,17 +129,26 @@ class TestConversions:
         self.helper(self.data.cell, keys, types)
 
     def test_cells_push_pull(self):
-        cell_dims = [(1,1), (1,3), (3,1), (1,1,1), (3,1,1,1), (1,3,1,1), (2,2,2)]
+        cell_dims = [
+            # (1,1), # error single value: Could not convert None (type <class 'NoneType'>) to array from scipy
+            (1,3),
+            (3,1),
+            # (1,1,1), # error single value: Could not convert None (type <class 'NoneType'>) to array from scipy
+            (3,1,1,1),
+            (1,3,1,1),
+            (2,2,2)
+            ]
         for cell_dim in cell_dims:
-            print(f"Start testing {cell_dim}")
-            self.oc.eval(f"x = cell{cell_dim};")
+            # print(f"Start testing {cell_dim}")
+            self.oc.eval(f"x = cell{cell_dim}; x(:)=1;")
             x_ = self.oc.pull('x')
-            print(np.shape(x_))
+            # print(np.shape(x_))
             assert np.allclose(np.atleast_2d(np.shape(x_)), self.oc.eval('size(x)', verbose=False))
 
+            # print(x_)
             self.oc.push('x', x_)
             x_ = self.oc.pull('x')
-            print(np.shape(x_))
+            # print(np.shape(x_))
             assert np.allclose(np.atleast_2d(np.shape(x_)), self.oc.eval('size(x)', verbose=False))
 
     def test_python_conversions(self):

--- a/oct2py/tests/test_conversions.py
+++ b/oct2py/tests/test_conversions.py
@@ -135,12 +135,12 @@ class TestConversions:
             self.oc.eval(f"x = cell{cell_dim};")
             x_ = self.oc.pull('x')
             print(np.shape(x_))
-            assert np.array_equal(np.atleast_2d(np.shape(x_)).astype(float), self.oc.eval('size(x)', verbose=False))
+            assert np.allclose(np.atleast_2d(np.shape(x_)), self.oc.eval('size(x)', verbose=False))
 
             self.oc.push('x', x_)
             x_ = self.oc.pull('x')
             print(np.shape(x_))
-            assert np.array_equal(np.atleast_2d(np.shape(x_)).astype(float), self.oc.eval('size(x)', verbose=False))
+            assert np.allclose(np.atleast_2d(np.shape(x_)), self.oc.eval('size(x)', verbose=False))
 
     def test_python_conversions(self):
         """Test roundtrip python type conversions

--- a/oct2py/tests/test_conversions.py
+++ b/oct2py/tests/test_conversions.py
@@ -128,6 +128,17 @@ class TestConversions:
         types = [Cell for i in range(len(keys))]
         self.helper(self.data.cell, keys, types)
 
+    def test_cells_push_pull(self):
+        cell_dims = [(1,3), (3,1), (1,1), (1,1,1), (3,1,1,1), (1,3,1,1), (2,2,2)]
+        for cell_dim in cell_dims:
+            self.oc.eval(f"x = cell{cell_dims};")
+            x_ = self.oc.pull('x')
+            assert np.shape(x_) == cell_dims
+
+            self.oc.push('x', x_)
+            x_ = self.oc.pull('x')
+            assert np.shape(x_) == cell_dims
+
     def test_python_conversions(self):
         """Test roundtrip python type conversions
         """

--- a/oct2py/tests/test_conversions.py
+++ b/oct2py/tests/test_conversions.py
@@ -130,10 +130,10 @@ class TestConversions:
 
     def test_cells_push_pull(self):
         cell_dims = [
-            # (1,1), # error single value: Could not convert None (type <class 'NoneType'>) to array from scipy
+            (1,1),
             (1,3),
             (3,1),
-            # (1,1,1), # error single value: Could not convert None (type <class 'NoneType'>) to array from scipy
+            (1,1,1),
             (3,1,1,1),
             (1,3,1,1),
             (2,2,2)

--- a/oct2py/tests/test_conversions.py
+++ b/oct2py/tests/test_conversions.py
@@ -129,15 +129,18 @@ class TestConversions:
         self.helper(self.data.cell, keys, types)
 
     def test_cells_push_pull(self):
-        cell_dims = [(1,3), (3,1), (1,1), (1,1,1), (3,1,1,1), (1,3,1,1), (2,2,2)]
+        cell_dims = [(1,1), (1,3), (3,1), (1,1,1), (3,1,1,1), (1,3,1,1), (2,2,2)]
         for cell_dim in cell_dims:
-            self.oc.eval(f"x = cell{cell_dims};")
+            print(f"Start testing {cell_dim}")
+            self.oc.eval(f"x = cell{cell_dim};")
             x_ = self.oc.pull('x')
-            assert np.shape(x_) == cell_dims
+            print(np.shape(x_))
+            assert np.array_equal(np.atleast_2d(np.shape(x_)).astype(float), self.oc.eval('size(x)', verbose=False))
 
             self.oc.push('x', x_)
             x_ = self.oc.pull('x')
-            assert np.shape(x_) == cell_dims
+            print(np.shape(x_))
+            assert np.array_equal(np.atleast_2d(np.shape(x_)).astype(float), self.oc.eval('size(x)', verbose=False))
 
     def test_python_conversions(self):
         """Test roundtrip python type conversions


### PR DESCRIPTION
I haven't run the test. How to run the test?

___

I vote to make atleast2d as default since that is what octave do. Furthermore, passing cell from octave to python already got auto squeze in the other part of the code(?), so we can remove the hardcoded squeeze in python part of Cell?