### PR TITLE
Add macOS CI job for test_usage.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,19 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  macos:
+    runs-on: macos-latest
+    env:
+      TERM: dumb
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - uses: taiki-e/install-action@just
+      - name: Install Octave
+        run: brew install octave
+      - name: Run tests
+        run: just test tests/test_usage.py
+
   check_release:
     runs-on: ubuntu-latest
     steps:
@@ -89,6 +102,7 @@ jobs:
     if: always()
     needs:
       - build
+      - macos
       - pre_commit
       - typing
       - docs

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pickle
+import sys
 import tempfile
 from io import StringIO
 
@@ -121,6 +122,7 @@ class TestUsage:
         a = self.oc.pull("a")
         assert a == 1
 
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
     def test_extract_figures(self):
         plot_dir = tempfile.mkdtemp().replace("\\", "/")
         code = """
@@ -144,6 +146,7 @@ class TestUsage:
         with pytest.raises(Oct2PyError):
             self.oc.eval("a = ones2(1)")
 
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
     def test_keyword_arguments(self):
         self.oc.set(0, DefaultFigureColor="b", nout=0)
         plot_dir = tempfile.mkdtemp().replace("\\", "/")
@@ -327,6 +330,7 @@ class TestUsage:
         with pytest.raises(Oct2PyError, match=exp):
             self.oc.pyeval_like_error3(1)
 
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
     def test_pkg_load(self):
         self.oc.eval("pkg load signal")
         t = np.linspace(0, 1, num=100)


### PR DESCRIPTION
## Summary

- Adds a `macos` CI job that runs on `macos-latest`, installs Octave via Homebrew, and runs `just test tests/test_usage.py`
- Sets `TERM=dumb` environment variable in the macOS job
- Adds `@pytest.mark.skipif(sys.platform != "linux", ...)` to `test_extract_figures`, `test_keyword_arguments`, and `test_pkg_load` so they are skipped on non-Linux platforms
- Includes `macos` in the `tests_check` branch protection job

## Test plan

- [x] Verify the `macos` CI job runs successfully on macOS
- [x] Confirm the three Linux-only tests are skipped on macOS
- [x] Confirm the three tests still run (and pass) on Linux