### PR TITLE
docs: document qt backend requirements and OCTAVE_EXECUTABLE

### DIFF
--- a/docs/source/info.rst
+++ b/docs/source/info.rst
@@ -131,7 +131,26 @@ timeout.
 
 Graphics Toolkit
 ================
-Oct2Py uses the ``qt`` graphics toolkit by default.  To change toolkits:
+On newer versions of Octave, ``qt`` is only available when Octave is started with a
+display.  By default, oct2py runs ``octave-cli``, which only supports
+``gnuplot`` (or ``fltk`` in some cases) and has limited support for rendering
+or interactive plots.
+
+To use the ``qt`` backend, set the ``OCTAVE_EXECUTABLE`` environment variable
+to ``octave`` or the path to your Octave executable before starting your
+session:
+
+.. code-block:: bash
+
+    $ export OCTAVE_EXECUTABLE=octave
+
+On headless or remote systems, you may need to use a virtual framebuffer:
+
+.. code-block:: bash
+
+    $ export OCTAVE_EXECUTABLE="xvfb-run octave"
+
+To inspect or change the active toolkit at runtime:
 
 .. code-block:: pycon
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -51,6 +51,26 @@ GNU Octave Installation
 - Alternatively, you can specify the path to your Octave executable by
   creating an ``OCTAVE_EXECUTABLE`` environmental variable.
 
+Graphics Backend (Qt vs gnuplot)
+---------------------------------
+By default, oct2py runs ``octave-cli``, which only supports the ``gnuplot``
+backend (or ``fltk`` in some cases) and has limited support for rendering or
+interactive plots.  On newer versions of Octave, the ``qt`` graphics toolkit
+is only available when Octave is started with a display.
+
+To use the ``qt`` backend for rendering or interactive plots, set
+``OCTAVE_EXECUTABLE`` to ``octave`` or the path to your Octave executable:
+
+.. code-block:: bash
+
+    $ export OCTAVE_EXECUTABLE=octave
+
+On remote or headless systems you can use a virtual framebuffer:
+
+.. code-block:: bash
+
+    $ export OCTAVE_EXECUTABLE="xvfb-run octave"
+
 .. _Anaconda: https://conda.io/projects/conda/en/latest/user-guide/install/index.html
 .. _pip: http://www.pip-installer.org/en/latest/installing.html
 .. _Octave:  https://octave.org/doc/interpreter/Installation.html


### PR DESCRIPTION
## Summary

- On newer Octave versions, the `qt` graphics toolkit is only available when Octave is started with a display; `octave-cli` (the default) only supports `gnuplot` or `fltk`
- Add a new "Graphics Backend (Qt vs gnuplot)" section in `installation.rst` explaining this limitation and how to set `OCTAVE_EXECUTABLE`
- Expand the "Graphics Toolkit" section in `info.rst` with the same context and instructions for headless/remote systems using `xvfb-run`