### PR TITLE
Drop legacy scipy compatibility shims and bump minimum versions

### DIFF
--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -7,17 +7,9 @@ import inspect
 import threading
 
 import numpy as np
-
-try:
-    from scipy.io import loadmat, savemat
-    from scipy.io.matlab import MatlabFunction, MatlabObject
-    from scipy.sparse import spmatrix
-except ImportError:
-    try:  # noqa
-        from scipy.io.matlab.mio5 import MatlabFunction, MatlabObject  # type:ignore[assignment]
-    except ImportError:
-        pass
-
+from scipy.io import loadmat, savemat
+from scipy.io.matlab import MatlabFunction, MatlabObject
+from scipy.sparse import spmatrix
 
 try:
     from pandas import DataFrame, Series

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "numpy >=1.12",
-    "scipy >=0.17",
+    "numpy >=1.24",
+    "scipy >=1.9.0",
     "octave_kernel >= 0.38.0",
 ]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1409,9 +1409,9 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numpy", specifier = ">=1.12" },
+    { name = "numpy", specifier = ">=1.24" },
     { name = "octave-kernel", specifier = ">=0.38.0" },
-    { name = "scipy", specifier = ">=0.17" },
+    { name = "scipy", specifier = ">=1.9.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Fixes #331

- Remove try/except import fallbacks for old scipy internal APIs (`scipy.io.matlab.mio5`) that were only needed for scipy < 1.0
- Simplify imports in `io.py` to use the stable public API directly
- Bump minimum dependency versions: numpy >=1.24, scipy >=1.9.0
