### PR TITLE
Bump octave_kernel action to v0.39.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@93556350e3433849ea434d68e8b8f7d9e9a402a4 # v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@93556350e3433849ea434d68e8b8f7d9e9a402a4 # v1
         with:
-          ignore_links: "https://github.com/blink1073/oct2py/blob/main/CHANGELOG.md http://nbviewer.jupyter.org/*"
+          ignore_links: "https://github.com/blink1073/oct2py/blob/main/CHANGELOG.md http://nbviewer.org/*"
 
   tests_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ trust a code translator, this is your library.
 ## Features
 
 - Supports all Octave datatypes and most Python datatypes and Numpy dtypes.
-- Provides [OctaveMagic](https://nbviewer.jupyter.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1) for IPython, including inline plotting in notebooks.
+- Provides [OctaveMagic](https://nbviewer.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1) for IPython, including inline plotting in notebooks.
 - Supports cell arrays and structs/struct arrays with arbitrary nesting.
 - Supports sparse matrices.
 - Builds methods on the fly linked to Octave commands (e.g. `zeros` above).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,7 +4,7 @@
 
 Oct2Py provides a plugin for IPython to bring Octave to the IPython
 prompt or the IPython
-[Notebook](http://nbviewer.jupyter.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1).
+[Notebook](http://nbviewer.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1).
 
 ## M-File Examples
 

--- a/docs/info.md
+++ b/docs/info.md
@@ -228,6 +228,6 @@ and will not interfere with any other session.
 ## IPython Notebook
 
 Oct2Py provides
-[OctaveMagic](http://nbviewer.jupyter.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1)
+[OctaveMagic](http://nbviewer.org/github/blink1073/oct2py/blob/main/example/octavemagic_extension.ipynb?create=1)
 for IPython, including inline plotting in notebooks. This requires
 IPython >= 1.0.0.


### PR DESCRIPTION
## Summary
- Bump `calysto/octave_kernel` action from v0.37.0/v0.37.1 to v0.39.0 (`72a4e04`) in both CI jobs