### PR TITLE
Auto-use /dev/shm tmpfs on Linux to reduce per-call overhead

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -591,8 +591,10 @@ class Oct2Py:
             # On Linux, /dev/shm is always in RAM and avoids disk latency,
             # which is critical for performance in Octave 7+ where save/load
             # can be significantly slower on disk-backed filesystems.
+            executable = self._engine.executable
+            sandboxed = "snap" in executable or "flatpak" in executable
             shm = "/dev/shm"  # noqa: S108
-            if osp.isdir(shm) and os.access(shm, os.W_OK):
+            if not sandboxed and osp.isdir(shm) and os.access(shm, os.W_OK):
                 self.temp_dir = tempfile.mkdtemp(dir=shm, prefix="oct2py_")
                 atexit.register(shutil.rmtree, self.temp_dir, True)
             else:


### PR DESCRIPTION
## Summary

- On Linux, automatically use `/dev/shm` (a RAM-based tmpfs) for the session's MAT file exchange directory when available and writable
- Each session gets a uniquely-named directory via `tempfile.mkdtemp`; cleanup is registered with `atexit` and also runs eagerly in `exit()`
- Falls back to the existing engine temp directory on macOS, Windows, or when `/dev/shm` is unavailable
- User-provided `temp_dir` values are always respected and never auto-cleaned

## Background

Every `feval` call round-trips through disk files (`writer.mat` → Octave → `reader.mat`). In Octave 7+, the `save` command does more synchronous I/O, causing 1.5–2.5s overhead per call compared to ~0.02s in Octave 6.4.0. Using `/dev/shm` (always in RAM) eliminates disk latency entirely.

Users on macOS can get the same benefit by passing `temp_dir` pointing at a RAM disk mount.

## Test plan

- All existing tests pass (two pre-existing failures unrelated to this change)
- Manually verified session creates temp dir in `/dev/shm` on Linux, falls back correctly on macOS

Closes #291