### PR TITLE
Fix Octave subprocess leak in ThreadPoolExecutor

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -9,6 +9,7 @@ import os.path as osp
 import shutil
 import tempfile
 import warnings
+import weakref
 
 import numpy as np
 from metakernel.pexpect import EOF, TIMEOUT
@@ -115,6 +116,7 @@ class Oct2Py:
     def exit(self):
         """Quits this octave session and cleans up."""
         if self._engine:
+            atexit.unregister(self._engine._cleanup)
             self._engine.repl.terminate()
         self._engine = None
         if self._temp_dir_owner and self.temp_dir and osp.isdir(self.temp_dir):
@@ -586,8 +588,21 @@ class Oct2Py:
             # terminal processing after each function call (~0.5s on some
             # systems), which is unnecessary since oct2py drives Octave
             # programmatically via pexpect.
+            #
+            # Use a weakref-based wrapper so that OctaveEngine (and its atexit
+            # registration) does not hold a strong reference back to this Oct2Py
+            # instance, which would otherwise prevent __del__ / exit() from ever
+            # being called and cause Octave subprocesses to accumulate.
+            _weak_self = weakref.ref(self)
+
+            def _stdin_handler(line):
+                inst = _weak_self()
+                if inst is not None:
+                    return inst._handle_stdin(line)
+                return None
+
             self._engine = OctaveEngine(
-                stdin_handler=self._handle_stdin,
+                stdin_handler=_stdin_handler,
                 logger=self.logger,
                 cli_options="--no-line-editing",
             )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,8 +1,10 @@
+import gc
 import glob
 import logging
 import os
 import shutil
 import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import StringIO
 
 import numpy as np
@@ -106,6 +108,31 @@ class TestMisc:
             thread_check()
         except TypeError:
             thread_check.thread_check()  # type:ignore[attr-defined]
+
+    def test_threadpool_no_process_leak(self):
+        """Oct2Py sessions created in a ThreadPoolExecutor must not leak Octave
+        subprocesses after the threads complete (issue #289)."""
+        import psutil
+
+        proc = psutil.Process(os.getpid())
+        initial = len(proc.children(recursive=True))
+
+        def run():
+            oc = Oct2Py()
+            result = oc.sum([1, 2, 3])
+            return result
+
+        for _ in range(2):
+            with ThreadPoolExecutor(max_workers=3) as executor:
+                futures = [executor.submit(run) for _ in range(3)]
+                for future in as_completed(futures):
+                    future.result()
+            gc.collect()
+
+        final = len(proc.children(recursive=True))
+        assert final <= initial + 1, (
+            f"Octave process leak detected: started with {initial} children, ended with {final}"
+        )
 
     def test_speed_check(self):
         from oct2py import speed_check


### PR DESCRIPTION
Closes #289

## Summary

- `OctaveEngine.__init__` registers `self._cleanup` with `atexit`, creating a strong reference chain: `atexit` → `OctaveEngine._cleanup` → `OctaveEngine` → `stdin_handler` → `Oct2Py`. This prevented `Oct2Py.__del__` from ever firing, so Octave subprocesses accumulated with each `ThreadPoolExecutor` iteration.
- Fix: pass a `weakref`-based closure as `stdin_handler` so `OctaveEngine` no longer holds a strong reference back to the `Oct2Py` instance.
- Also call `atexit.unregister(self._engine._cleanup)` in `exit()` to avoid a redundant cleanup attempt on an already-terminated session.

## Test plan

- [x] New regression test `test_threadpool_no_process_leak` verifies that child Octave processes do not accumulate across multiple `ThreadPoolExecutor` iterations
- [x] All existing `test_misc.py` tests pass (one pre-existing unrelated failure in `test_func_without_docstring` due to an Octave version string change)