### PR TITLE
Fix deep recursion crashing Octave session

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -629,6 +629,11 @@ class Oct2Py:
         # Add local Octave scripts.
         self._engine.eval('addpath("%s");' % HERE.replace(osp.sep, "/"))
 
+        # Octave's default max_recursion_depth is 256, which is lower than
+        # MATLAB's default and causes deep recursive functions to crash the
+        # session.  Raise it to match a more permissive default (issue #326).
+        self._engine.eval("max_recursion_depth(2500);")
+
     def _feval(  # noqa
         self,
         func_name,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,7 @@ import glob
 import logging
 import os
 import shutil
+import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import StringIO
@@ -337,6 +338,17 @@ class TestMisc:
         """Calling a .m script (not a function) with default nout should work (issue #332)."""
         result = self.oc.feval("test_octave_script")
         assert result is None
+
+    @pytest.mark.skipif(
+        sys.platform == "darwin",
+        reason="macOS pre-allocates an 8 MB main-thread stack for the Octave "
+        "subprocess that cannot be enlarged from Python",
+    )
+    def test_recursive_function(self):
+        """Recursive functions should work for deep recursion (issue #326)."""
+        n = 300
+        result = self.oc.test_recurse(n)
+        assert result == n * (n + 1) / 2
 
     def test_feval_script_with_args(self):
         """Calling a .m script with args should make them available via argv (issue #332)."""

--- a/tests/test_recurse.m
+++ b/tests/test_recurse.m
@@ -1,0 +1,8 @@
+function result = test_recurse(n)
+%TEST_RECURSE Return the sum 1+2+...+n via recursion.
+  if n <= 0
+    result = 0;
+  else
+    result = n + test_recurse(n - 1);
+  end
+end


### PR DESCRIPTION
Closes #326

## Summary

- Octave's default `max_recursion_depth` (256) sits above the effective OS stack capacity when the session is driven via pexpect, so deeply recursive user functions kill the Octave subprocess instead of raising a clean error
- Raises `max_recursion_depth` to 2500 in `restart()` to match MATLAB's more permissive default, allowing deep recursion to succeed on Linux
- Adds a regression test using a simple recursive sum function (`n=300`); skipped on macOS where the kernel pre-allocates a fixed 8 MB main-thread stack that cannot be enlarged from Python

## Test plan

- [x] `just test tests/test_misc.py::TestMisc::test_recursive_function` passes on Linux (skips on macOS)
- [x] Full test suite passes: `just test`