### PR TITLE
Fix codecov.yml structure to use canonical notify.after_n_builds

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 
 [run]
 branch = True
-relative_files = True
 omit =
     oct2py/tests/*
     oct2py/ipython/tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 
 [run]
 branch = True
+relative_files = True
 omit =
     oct2py/tests/*
     oct2py/ipython/tests/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Run example notebook
         run: just test-notebook
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           disable_search: true
-          verbose: true
 
   test-other:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,8 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          disable_search: true
           verbose: true
 
   test-other:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   test-other:
     runs-on: ${{ matrix.os }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,14 +4,16 @@ coverage:
       default:
         target: 90%
         threshold: 0%
-        # Wait for all 6 coverage uploads before reporting:
-        # 6 test (6x ubuntu-24.04, one per Python version)
-        after_n_builds: 6
     patch:
       default:
         target: 95%
         threshold: 0%
-        after_n_builds: 6
+
+codecov:
+  notify:
+    # Wait for all 6 coverage uploads before reporting:
+    # 6 test (6x ubuntu-24.04, one per Python version)
+    after_n_builds: 6
 
 comment:
   layout: "reach,diff,flags,files"


### PR DESCRIPTION
## Summary

- Moves `after_n_builds` from per-status nesting to `codecov.notify`, matching the canonical Codecov configuration structure used in octave_kernel
- Removes redundant per-status `after_n_builds` entries