### PR TITLE
Add quiet parameter to eval/feval to suppress output capture

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -64,6 +64,33 @@ call `feval` with the full path.
 >>> octave.feval("/path/to/myscript", 1, 2)  # doctest: +SKIP
 ```
 
+## Suppressing Output Capture
+
+By default, `eval` and `feval` capture and return the Octave `ans` value.
+Passing `quiet=True` executes the command but discards the result entirely,
+returning `None`. This is useful in three situations:
+
+- **Inspecting struct fields in Jupyter** — without `quiet=True`, the value is
+  both printed by Octave and returned to the cell output, causing it to appear
+  twice.
+- **Non-serialisable types** — some Octave values (custom class objects, large
+  sparse arrays, etc.) cannot be serialised to a MAT file. `quiet=True` lets
+  you run the command for its side effects without triggering a serialisation
+  error.
+- **Fire-and-forget calls** — when you only care about the side effect (e.g.
+  setting a variable, calling `disp`) and do not need the return value.
+
+```pycon
+>>> from oct2py import octave
+>>> octave.push("s", {"field": [1, 2, 3]})
+>>> result = octave.eval("s.field", quiet=True)  # prints once, returns None
+>>> result is None
+True
+>>> result = octave.feval("max", [3, 1, 2], quiet=True)  # no return value
+>>> result is None
+True
+```
+
 ## Direct Interaction
 
 Oct2Py supports the Octave `keyboard` function which drops you into an

--- a/oct2py/_pyeval.m
+++ b/oct2py/_pyeval.m
@@ -42,7 +42,33 @@ try
     assignin('base', 'ans', sentinel);
 
     % Use the `ans` response if no output arguments are expected.
-    if req.nout == 0
+    % nout == -1 means "execute but discard all output" (no ans capture).
+    if req.nout == -1
+
+        if length(req.func_args)
+          try
+            feval(req.func_name, req.func_args{:});
+          catch ME
+            if ~isempty(strfind(ME.message, 'invalid call to script'))
+              assignin('base', 'argv', req.func_args);
+              try
+                evalin('base', req.func_name);
+              catch ME2
+                evalin('base', 'clear argv');
+                rethrow(ME2);
+              end
+              evalin('base', 'clear argv');
+            else
+              rethrow(ME);
+            end
+          end
+        else
+          feval(req.func_name)
+        end
+
+        result = { sentinel };
+
+    elseif req.nout == 0
 
         if length(req.func_args)
           try

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -352,6 +352,9 @@ class Oct2Py:
         nout : int or str, optional
             The desired number of returned values, defaults to 1. If nout
             value is 'max_nout', _get_max_nout() will be used.
+        quiet : bool, optional
+            If True, execute the function but do not capture or return any
+            output.  Takes precedence over ``nout``.
         store_as : str, optional
             If given, saves the result to the given Octave variable name
             instead of returning it.
@@ -417,7 +420,9 @@ class Oct2Py:
 
         # nout handler
         nout = kwargs.get("nout")
-        if nout is None:
+        if kwargs.get("quiet"):
+            nout = -1
+        elif nout is None:
             nout = 1
         elif nout == "max_nout":
             nout = self._get_max_nout(func_path)
@@ -482,6 +487,7 @@ class Oct2Py:
         plot_height=None,
         plot_res=None,
         nout=0,
+        quiet=False,
         **kwargs,
     ):
         """Evaluate an Octave command or commands.
@@ -502,6 +508,10 @@ class Oct2Py:
             The desired number of returned values, defaults to 0.  If nout
             is 0, the `ans` will be returned as the return value. If nout
             value is 'max_nout', _get_max_nout() will be used.
+        quiet : bool, optional
+            If True, execute the command(s) but do not capture or return any
+            output.  Useful when ``ans`` is not serialisable, or to avoid
+            double-printing in Jupyter.  Takes precedence over ``nout``.
         temp_dir: str, optional
             If specified, the session's MAT files will be created in the
             directory, otherwise a the instance `temp_dir` is used.
@@ -594,6 +604,7 @@ class Oct2Py:
                 "base",
                 cmd,
                 nout=nout,
+                quiet=quiet,
                 timeout=timeout,
                 stream_handler=stream_handler,
                 verbose=verbose,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -465,6 +465,19 @@ class TestMisc:
             assert result.label == "hi"
         # else: older Octave returns OctaveUserClass — non-crash is sufficient
 
+    def test_eval_quiet_discards_output(self):
+        """quiet=True should execute the command but return None (issue #211)."""
+        self.oc.push("x", 42)
+        result = self.oc.eval("x", quiet=True)
+        assert result is None
+        # Confirm default behaviour still returns ans for an expression
+        assert self.oc.eval("x + 0") == 42
+
+    def test_feval_quiet_discards_output(self):
+        """feval quiet=True should execute but return None (issue #211)."""
+        result = self.oc.feval("max", np.array([3, 1, 2]), quiet=True)
+        assert result is None
+
     def test_feval_script_with_args(self):
         """Calling a .m script with args should make them available via argv (issue #332)."""
         lines: list[str] = []


### PR DESCRIPTION
Closes #211.

## Summary

- Added `quiet=True` parameter to both `eval()` and `feval()`. When set, the command executes normally (printing output, running side effects) but no result is captured or returned — `None` is returned instead.
- Implemented in `_pyeval.m` via a new `nout == -1` branch that skips the `get_ans` call.
- Added a "Suppressing Output Capture" section to `docs/info.md` explaining the three use cases.
- Added tests for both `eval` and `feval` with `quiet=True`.

## Use cases addressed

- Inspecting struct fields in Jupyter without double-printing the value.
- Running commands that produce non-serialisable `ans` values (custom class objects, etc.).
- Fire-and-forget calls where only the side effect matters.