### PR TITLE
Add Oct2Py.run() to execute scripts in the base workspace

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -64,6 +64,37 @@ call `feval` with the full path.
 >>> octave.feval("/path/to/myscript", 1, 2)  # doctest: +SKIP
 ```
 
+## Running Scripts and Accessing Their Variables
+
+Octave scripts (as opposed to functions) assign variables directly into
+the caller's workspace. When you call a script through the dynamic
+dispatch mechanism (e.g. `octave.myscript()`), oct2py evaluates it
+inside a temporary function scope, so any variables the script creates
+are discarded when it returns and are not accessible via `pull`.
+
+Use `Oct2Py.run()` instead. It executes the script in Octave's **base
+workspace**, so variables it assigns persist and can be retrieved with
+`pull`:
+
+```pycon
+>>> from oct2py import Oct2Py
+>>> oc = Oct2Py()
+>>> # myscript.m contains: result = [1, 2, 3];
+>>> oc.run("/path/to/myscript.m")  # doctest: +SKIP
+>>> oc.pull("result")              # doctest: +SKIP
+array([1., 2., 3.])
+```
+
+`run` accepts the same optional keyword arguments as `eval` (`verbose`,
+`timeout`, `stream_handler`, etc.).
+
+> **Note:** This limitation does not apply to Octave *functions* — a
+> function's return values are passed back to Python normally via
+> `feval`. If you need to share data between Python and Octave in a
+> flexible way, prefer writing a function that accepts arguments and
+> returns results rather than relying on side-effects in the base
+> workspace.
+
 ## Suppressing Output Capture
 
 By default, `eval` and `feval` capture and return the Octave `ans` value.

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -626,6 +626,44 @@ class Oct2Py:
             return "\n".join(lines), ans
         return ans
 
+    def run(self, script, **kwargs):
+        """Run an Octave script file in the base workspace.
+
+        Unlike calling ``octave.run(script)`` via dynamic dispatch (which runs
+        the script inside a temporary function scope and discards any variables
+        it creates), this method executes the script through ``evalin('base',
+        ...)``, so variables assigned by the script persist in the Octave base
+        workspace and can be retrieved with :meth:`pull`.
+
+        Parameters
+        ----------
+        script : str
+            Name of the script or path to an ``.m`` file, passed directly to
+            Octave's ``run()`` built-in.
+        **kwargs
+            Additional keyword arguments forwarded to :meth:`eval` (e.g.
+            ``verbose``, ``timeout``, ``stream_handler``).
+
+        Examples
+        --------
+        >>> import os, tempfile
+        >>> from oct2py import Oct2Py
+        >>> oc = Oct2Py()
+        >>> with tempfile.NamedTemporaryFile(suffix='.m', mode='w', delete=False) as f:
+        ...     _ = f.write('b = 42;')
+        ...     script_path = f.name
+        >>> oc.run(script_path)
+        >>> oc.pull('b')
+        42.0
+        >>> oc.exit()
+        >>> os.unlink(script_path)
+        """
+        # Escape backslashes and single quotes so the path is safe inside
+        # an Octave single-quoted string literal.
+        safe = script.replace("\\", "/").replace("'", "''")
+        kwargs.setdefault("nout", 0)
+        self.eval(f"run('{safe}')", **kwargs)
+
     def restart(self):
         """Restart an Octave session in a clean state"""
         if self._engine:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -39,7 +39,11 @@ class TestUsage:
 
     def test_run_script_creates_workspace_variables(self):
         """Variables assigned in a script run via run() persist (issue #239)."""
-        with tempfile.NamedTemporaryFile(suffix=".m", mode="w", delete=False) as f:
+        # Write the script into temp_dir so sandboxed Octave (snap/flatpak)
+        # can access it.
+        with tempfile.NamedTemporaryFile(
+            suffix=".m", mode="w", delete=False, dir=self.oc.temp_dir
+        ) as f:
             f.write("issue239_var = [1, 2, 3];")
             script_path = f.name
         try:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -37,6 +37,18 @@ class TestUsage:
         with pytest.raises(Oct2PyError):
             self.oc.eval("_spam")
 
+    def test_run_script_creates_workspace_variables(self):
+        """Variables assigned in a script run via run() persist (issue #239)."""
+        with tempfile.NamedTemporaryFile(suffix=".m", mode="w", delete=False) as f:
+            f.write("issue239_var = [1, 2, 3];")
+            script_path = f.name
+        try:
+            self.oc.run(script_path)
+            result = self.oc.pull("issue239_var")
+            assert np.allclose(result, np.array([1, 2, 3]))
+        finally:
+            os.unlink(script_path)
+
     def test_dynamic_functions(self):
         """Test some dynamic functions"""
         if self.oc._engine.executable.startswith("flatpak"):


### PR DESCRIPTION
## References

Closes #239

## Description

`octave.run('script')` was evaluated via dynamic dispatch (`feval`), which runs the script inside a temporary function scope. Any variables the script assigned were discarded when it returned, making them inaccessible via `pull`.

## Changes

- Added `Oct2Py.run(script, **kwargs)` method that executes the script through `evalin('base', ...)`, so variables it assigns persist in the Octave base workspace.
- Added `test_run_script_creates_workspace_variables` to `tests/test_usage.py` to confirm variables are accessible via `pull` after `run`.
- Added a "Running Scripts and Accessing Their Variables" section to `docs/info.md` explaining the limitation and how to use `run`.

## Backwards-incompatible changes

None

## Testing

New test `TestUsage::test_run_script_creates_workspace_variables` writes a temporary `.m` file, calls `run()`, and asserts the variable can be retrieved with `pull`.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)