### PR TITLE
Add workspace proxy for MATLAB-style variable access

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,10 @@ jupyter:
 
 ::: oct2py.Oct2Py
 
+## OctaveWorkspaceProxy
+
+::: oct2py.OctaveWorkspaceProxy
+
 ## Struct
 
 ::: oct2py.Struct

--- a/docs/info.md
+++ b/docs/info.md
@@ -47,6 +47,25 @@ only see this if you were using logging).
 1.0
 ```
 
+## Workspace Access
+
+The `workspace` attribute provides a dict-like interface to the Octave base
+workspace, mirroring the `eng.workspace` API in MATLAB's Python engine:
+
+```pycon
+>>> from oct2py import octave
+>>> octave.eval("x = 5", nout=0)
+>>> octave.workspace["x"]
+5.0
+>>> octave.workspace["y"] = [1, 2, 3]
+>>> octave.pull("y")
+array([[1., 2., 3.]])
+>>> del octave.workspace["y"]
+```
+
+This is equivalent to using `push` and `pull` directly, but can be more
+natural when porting code from MATLAB's Python engine.
+
 ## Using M-Files
 
 In order to use an m-file in Oct2Py you must first call `addpath` for

--- a/oct2py/__init__.py
+++ b/oct2py/__init__.py
@@ -24,7 +24,7 @@ trust a code translator, this is your library.
 from .utils import Oct2PyError, get_log  # noqa
 
 from ._version import __version__
-from .core import Oct2Py
+from .core import Oct2Py, OctaveWorkspaceProxy
 from .demo import demo
 from .io import Cell, Struct, StructArray
 from .speed_check import speed_check
@@ -34,6 +34,7 @@ __all__ = [
     "Cell",
     "Oct2Py",
     "Oct2PyError",
+    "OctaveWorkspaceProxy",
     "Struct",
     "StructArray",
     "__version__",

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -82,9 +82,10 @@ class OctaveWorkspaceProxy:
         The Oct2Py session to proxy.
     """
 
+    _session: "Oct2Py"
+
     def __init__(self, session):
-        # Use object.__setattr__ to avoid triggering Oct2Py.__setattr__
-        object.__setattr__(self, "_session", session)
+        self._session = session
 
     def __getitem__(self, name):
         """Return the named variable from the Octave workspace."""

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -67,6 +67,45 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_reset_instances_after_fork)
 
 
+class OctaveWorkspaceProxy:
+    """Dict-like proxy for the Octave base workspace.
+
+    Allows MATLAB-style variable access::
+
+        octave.workspace['x'] = 5
+        octave.workspace['x']   # returns 5.0
+        del octave.workspace['x']
+
+    Parameters
+    ----------
+    session : Oct2Py
+        The Oct2Py session to proxy.
+    """
+
+    def __init__(self, session):
+        # Use object.__setattr__ to avoid triggering Oct2Py.__setattr__
+        object.__setattr__(self, "_session", session)
+
+    def __getitem__(self, name):
+        """Return the named variable from the Octave workspace."""
+        return self._session.pull(name)
+
+    def __setitem__(self, name, value):
+        """Set a variable in the Octave workspace."""
+        self._session.push(name, value)
+
+    def __delitem__(self, name):
+        """Delete a variable from the Octave workspace."""
+        exist = self._session._exist(name)
+        if exist != 1:
+            raise KeyError(name)
+        self._session.eval('clear("%s")' % name, verbose=False)
+
+    def __repr__(self):
+        """Return a string representation of the proxy."""
+        return f"OctaveWorkspaceProxy({self._session!r})"
+
+
 class Oct2Py:
     """Manages an Octave session.
 
@@ -663,6 +702,22 @@ class Oct2Py:
         safe = script.replace("\\", "/").replace("'", "''")
         kwargs.setdefault("nout", 0)
         self.eval(f"run('{safe}')", **kwargs)
+
+    @property
+    def workspace(self):
+        """A dict-like proxy for the Octave base workspace.
+
+        Supports MATLAB-style variable access::
+
+            octave.workspace['x'] = 5
+            octave.workspace['x']   # returns 5.0
+            del octave.workspace['x']
+
+        Returns
+        -------
+        OctaveWorkspaceProxy
+        """
+        return OctaveWorkspaceProxy(self)
 
     def restart(self):
         """Restart an Octave session in a clean state"""

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -490,6 +490,10 @@ class TestMisc:
         with pytest.raises(Oct2PyError):
             self.oc.pull("y")
 
+        # Deleting a non-variable (e.g. a built-in function, exist != 1) raises KeyError
+        with pytest.raises(KeyError):
+            del self.oc.workspace["sin"]
+
     def test_feval_script_with_args(self):
         """Calling a .m script with args should make them available via argv (issue #332)."""
         lines: list[str] = []

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -478,6 +478,18 @@ class TestMisc:
         result = self.oc.feval("max", np.array([3, 1, 2]), quiet=True)
         assert result is None
 
+    def test_workspace_proxy(self):
+        """workspace attribute should support dict-style get/set/delete (issue #190)."""
+        self.oc.eval("x = 5", nout=0)
+        assert self.oc.workspace["x"] == 5.0
+
+        self.oc.workspace["y"] = 42
+        assert self.oc.pull("y") == 42.0
+
+        del self.oc.workspace["y"]
+        with pytest.raises(Oct2PyError):
+            self.oc.pull("y")
+
     def test_feval_script_with_args(self):
         """Calling a .m script with args should make them available via argv (issue #332)."""
         lines: list[str] = []


### PR DESCRIPTION
## References

Closes #190

## Description

Adds an `OctaveWorkspaceProxy` class and an `Oct2Py.workspace` property
that mirrors the `eng.workspace` dict API from MATLAB's Python engine,
allowing users to get, set, and delete Octave base-workspace variables
using subscript syntax.

## Changes

- `oct2py/core.py`: new `OctaveWorkspaceProxy` class; `Oct2Py.workspace` property
- `oct2py/__init__.py`: export `OctaveWorkspaceProxy` in public API
- `docs/info.md`: new "Workspace Access" section with usage example
- `docs/api.md`: added `OctaveWorkspaceProxy` to API reference
- `tests/test_misc.py`: `test_workspace_proxy` covering get, set, and delete

## Backwards-incompatible changes

None

## Testing

New test `TestMisc::test_workspace_proxy` covers the three operations
(get, set, delete) matching the use case from the issue.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code