### PR TITLE
Fix _pyeval.m: guard dname and store_as with isfield() (closes #180)

### DIFF
--- a/oct2py/_pyeval.m
+++ b/oct2py/_pyeval.m
@@ -28,7 +28,7 @@ try
     req = load(input_file);
 
     % Add function path to current path.
-    if req.dname
+    if isfield(req, 'dname') && req.dname
         addpath(req.dname);
     end
 
@@ -130,7 +130,7 @@ try
       end
     end
 
-    if req.store_as
+    if isfield(req, 'store_as') && req.store_as
       assignin('base', req.store_as, result{1});
       result = { sentinel };
     end

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -488,3 +488,83 @@ class TestMisc:
             stream_handler=lines.append,
         )
         assert any("hello_from_oct2py" in line for line in lines)
+
+    def test_pyeval_missing_dname_issue_180(self):
+        """_pyeval.m handles a request struct without 'dname' (issue #180).
+
+        When dname is absent from the MAT request file, ``if req.dname`` in
+        _pyeval.m raises "structure has no member 'dname'".  The fix guards
+        the field access with isfield() so the call succeeds.
+        """
+        import scipy.io
+
+        from oct2py.io import read_file
+
+        oc = self.oc
+
+        # Encode a single numeric argument as a 1-element object array (cell).
+        func_arg = np.array([-3.0])
+        encoded = np.empty(1, dtype=object)
+        encoded[0] = func_arg
+
+        req = {
+            "func_name": "abs",
+            "func_args": encoded,
+            "nout": np.float64(1),
+            "store_as": "",
+            "ref_indices": np.array([]),
+            # "dname" intentionally omitted — simulates the condition that
+            # triggered the original "structure has no member 'dname'" error.
+        }
+
+        out_file = os.path.join(oc.temp_dir, "writer.mat")
+        in_file = os.path.join(oc.temp_dir, "reader.mat")
+
+        scipy.io.savemat(out_file, req, appendmat=False, oned_as="row", long_field_names=True)
+        out_file_fwd = out_file.replace(os.sep, "/")
+        in_file_fwd = in_file.replace(os.sep, "/")
+        oc._engine.eval(f'_pyeval("{out_file_fwd}", "{in_file_fwd}");')
+
+        resp = read_file(in_file, oc)
+        assert not resp["err"], f"_pyeval raised: {resp['err']}"
+        result = resp["result"].ravel().tolist()
+        assert result[0] == 3.0
+
+    def test_pyeval_missing_store_as(self):
+        """_pyeval.m handles a request struct without 'store_as'.
+
+        Mirrors the dname guard: if 'store_as' is absent from the request,
+        ``if req.store_as`` raises "structure has no member 'store_as'".
+        The isfield() guard prevents this.
+        """
+        import scipy.io
+
+        from oct2py.io import read_file
+
+        oc = self.oc
+
+        func_arg = np.array([-5.0])
+        encoded = np.empty(1, dtype=object)
+        encoded[0] = func_arg
+
+        req = {
+            "func_name": "abs",
+            "func_args": encoded,
+            "dname": "",
+            "nout": np.float64(1),
+            "ref_indices": np.array([]),
+            # "store_as" intentionally omitted
+        }
+
+        out_file = os.path.join(oc.temp_dir, "writer.mat")
+        in_file = os.path.join(oc.temp_dir, "reader.mat")
+
+        scipy.io.savemat(out_file, req, appendmat=False, oned_as="row", long_field_names=True)
+        out_file_fwd = out_file.replace(os.sep, "/")
+        in_file_fwd = in_file.replace(os.sep, "/")
+        oc._engine.eval(f'_pyeval("{out_file_fwd}", "{in_file_fwd}");')
+
+        resp = read_file(in_file, oc)
+        assert not resp["err"], f"_pyeval raised: {resp['err']}"
+        result = resp["result"].ravel().tolist()
+        assert result[0] == 5.0


### PR DESCRIPTION
## References

Closes #180

## Description

`_pyeval.m` accessed `req.dname` and `req.store_as` with bare `if` checks.
When either field is absent from the request struct loaded from the MAT file,
Octave raises `"structure has no member '<field>'"` — the exact error reported
in #180 (`interp2` failing with `"structure has no member 'dname'"`).

This could happen when the request MAT file was written by a version of oct2py
that did not include those fields (e.g. after an upgrade from 3.x to 5.x).

## Changes

- `oct2py/_pyeval.m`: wrap `if req.dname` and `if req.store_as` with
  `isfield(req, '<field>') &&` guards so missing fields degrade gracefully.
- `tests/test_misc.py`: two regression tests (`test_pyeval_missing_dname_issue_180`,
  `test_pyeval_missing_store_as`) that craft request MAT files with each field
  intentionally omitted and assert `_pyeval` succeeds rather than raising.

## Backwards-incompatible changes

None

## Testing

Both new tests failed before the fix (with the exact Octave error from #180)
and pass after. Full test suite: 173 passed, 4 skipped, 2 xfailed.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code