### PR TITLE
Fix coverage upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,8 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          disable_search: true
+          files: ./coverage.xml
+          plugins: ""   # <-- disables the Python (and other) plugins
 
   test-other:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!--
Thanks for contributing to Oct2Py!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/blink1073/oct2py/blob/main/CONTRIBUTING.md
-->

## References

<!-- issue numbers -->

## Description

<!-- describe this PR -->
Fix codecov upload by preventing codecov from regenerating the coverage.xml file.

## Changes

<!-- list key changes -->
Update the codecov upload step to disable the codecov plugins (so it doesn't try to generate the file).

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet
