### PR TITLE
Convert scipy TypeError to Oct2PyError for char encoding issues

### DIFF
--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -40,6 +40,16 @@ def read_file(path, session=None, keep_matlab_shapes=False):
         data = loadmat(path, struct_as_record=True)
     except UnicodeDecodeError as e:
         raise Oct2PyError(str(e)) from None
+    except TypeError as e:
+        # Some Octave versions (e.g. 6.x on Windows) write char arrays with a
+        # mismatched byte-width that scipy cannot read.  Upgrading Octave to
+        # version 7 or later resolves the issue.
+        msg = (
+            f"{e}. "
+            "This is typically caused by a character-encoding bug in older "
+            "Octave versions (< 7) on Windows. Upgrading Octave should fix it."
+        )
+        raise Oct2PyError(msg) from None
     out = {}
     for key, value in data.items():
         out[key] = _extract(value, session, keep_matlab_shapes)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -53,6 +53,21 @@ class TestMisc:
         """Make sure unicode docstrings in Octave functions work"""
         help(self.oc.test_datatypes)
 
+    def test_loadmat_typeerror_raises_oct2pyerror(self):
+        """scipy TypeError for char encoding bug in old Octave becomes Oct2PyError (#179)."""
+        from unittest.mock import patch
+
+        from oct2py.io import read_file
+
+        with (
+            patch(
+                "oct2py.io.loadmat",
+                side_effect=TypeError("buffer is too small for requested array"),
+            ),
+            pytest.raises(Oct2PyError, match="character-encoding bug in older Octave"),
+        ):
+            read_file("/nonexistent.mat")
+
     def test_context_manager(self):
         """Make sure oct2py works within a context manager"""
         with Oct2Py() as oc1:


### PR DESCRIPTION
## References

Closes #179

## Description

Some older Octave versions (6.x on Windows) write `mxCHAR_CLASS` arrays
with a mismatched byte-width in the MAT5 file — the declared type is
`miUINT16` but only 1 byte per character is written instead of 2.
When scipy tries to read such a file it raises:

```
TypeError: buffer is too small for requested array
```

Previously this propagated as an opaque internal scipy traceback.

## Changes

- `oct2py/io.py`: `read_file` now catches `TypeError` from `loadmat`
  and re-raises it as `Oct2PyError` with a message identifying the
  cause and directing users to upgrade Octave (≥ 7 resolves the issue).
- `tests/test_misc.py`: new test that mocks `loadmat` raising
  `TypeError` and asserts the resulting `Oct2PyError` contains the
  helpful message.

## Backwards-incompatible changes

None

## Testing

New unit test added; full suite passes.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code