### PR TITLE
Fix classdef return for classes with required-argument constructors

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -996,9 +996,10 @@ class Oct2Py:
         self._function_ptrs.setdefault(name, func(self, name))
         return self._function_ptrs[name]
 
-    def _get_user_class(self, name):
+    def _get_user_class(self, name, attrs=None):
         """Get or create a user class of the given type."""
-        self._user_classes.setdefault(name, _make_user_class(self, name))
+        if name not in self._user_classes:
+            self._user_classes[name] = _make_user_class(self, name, attrs=attrs)
         return self._user_classes[name]
 
     def __getattr__(self, attr):

--- a/oct2py/dynamic.py
+++ b/oct2py/dynamic.py
@@ -227,10 +227,31 @@ class OctaveUserClass:
         return OctavePtr(instance._ref, instance._name, instance._address)
 
 
-def _make_user_class(session, name):
-    """Make an Octave class for a given class name"""
-    attrs = session.eval("fieldnames(%s);" % name, nout=1).ravel().tolist()
-    methods = session.eval("methods(%s);" % name, nout=1).ravel().tolist()
+def _make_user_class(session, name, attrs=None):
+    """Make an Octave class for a given class name.
+
+    Parameters
+    ----------
+    session : Oct2Py
+        The active Octave session.
+    name : str
+        The class name (or workspace variable name for old-style classes).
+    attrs : list of str, optional
+        Known property names.  When provided (e.g. read from a MatlabObject's
+        dtype), Octave is not queried with ``fieldnames(name)``.  This avoids
+        an error when the class constructor requires arguments.
+
+    Returns
+    -------
+    type
+        A new class derived from ``OctaveUserClass`` representing the Octave class.
+    """
+    if attrs is None:
+        attrs = session.eval("fieldnames(%s);" % name, nout=1).ravel().tolist()
+    try:
+        methods = session.eval("methods(%s);" % name, nout=1).ravel().tolist()
+    except Exception:
+        methods = []
     ref = weakref.ref(session)
 
     doc = _DocDescriptor(ref, name)

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -266,7 +266,8 @@ def _extract(data, session=None, keep_matlab_shapes=False):  # noqa
 
     # Extract user defined classes.
     if isinstance(data, MatlabObject):
-        cls = session._get_user_class(data.classname)
+        attrs = list(data.dtype.names) if data.dtype.names else None
+        cls = session._get_user_class(data.classname, attrs=attrs)
         return cls.from_value(data)
 
     # Extract struct data.

--- a/tests/NoDefaultCtorClass.m
+++ b/tests/NoDefaultCtorClass.m
@@ -1,0 +1,21 @@
+% NoDefaultCtorClass: classdef fixture with a required-argument constructor.
+% Used by test_misc.py to verify issue #174 (returning classdef objects
+% whose constructor requires arguments does not raise an error).
+classdef NoDefaultCtorClass
+  properties
+    value
+    label
+  end
+  methods
+    function obj = NoDefaultCtorClass(v, l)
+      if nargin ~= 2
+        error('NoDefaultCtorClass requires exactly two arguments');
+      end
+      obj.value = v;
+      obj.label = l;
+    end
+    function r = doubled(obj)
+      r = obj.value * 2;
+    end
+  end
+end

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -493,6 +493,24 @@ class TestMisc:
             assert result.label == "hi"
         # else: older Octave returns OctaveUserClass — non-crash is sufficient
 
+    def test_classdef_required_ctor_return(self):
+        """Returning a classdef whose constructor requires arguments must not raise (issue #174).
+
+        Previously, _make_user_class called fieldnames(ClassName) which tries
+        to invoke the no-arg constructor.  For classes that require arguments
+        that raised an Oct2PyError.  The fix passes dtype.names from the
+        MatlabObject directly so fieldnames() is never called.
+        """
+        from oct2py.io import Struct
+
+        result = self.oc.feval("NoDefaultCtorClass", 5, "test", nout=1)
+        assert result is not None
+        if isinstance(result, Struct):
+            # Octave 11+: classdef converted to struct on save
+            assert int(result.value) == 5
+            assert result.label == "test"
+        # else: older Octave returns OctaveUserClass — non-crash is sufficient
+
     def test_eval_quiet_discards_output(self):
         """quiet=True should execute the command but return None (issue #211)."""
         self.oc.push("x", 42)


### PR DESCRIPTION
## References

Closes #174

## Description

Returning a classdef object from Octave raised an error when the class constructor required arguments. `_make_user_class` called `fieldnames(ClassName)` in Octave to discover properties, which tries to invoke the no-arg constructor. For classes that require arguments this raised an `Oct2PyError`.

## Changes

- `_make_user_class` (`dynamic.py`): accepts an optional `attrs` parameter; when provided, skips the `fieldnames()` call. Also wraps the `methods()` call in `try/except` so it degrades gracefully.
- `_get_user_class` (`core.py`): passes `attrs` through to `_make_user_class`; fixes a pre-existing eager-evaluation bug where `dict.setdefault` always called `_make_user_class` even when the class was already cached.
- `_extract` (`io.py`): passes `data.dtype.names` to `_get_user_class` when reading a `MatlabObject`, so field names come from the MAT file data rather than requiring Octave to instantiate the class.
- New fixture `tests/NoDefaultCtorClass.m` and test `test_classdef_required_ctor_return` covering the issue scenario.

## Backwards-incompatible changes

None

## Testing

New test `TestMisc::test_classdef_required_ctor_return` added. Full suite passes (175 passed).

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code