### PR TITLE
Preserve SIGINT handler across engine startup (closes #168)

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -8,7 +8,9 @@ import logging
 import os
 import os.path as osp
 import shutil
+import signal
 import tempfile
+import threading
 import warnings
 import weakref
 
@@ -730,6 +732,20 @@ class Oct2Py:
         if "OCTAVE_EXECUTABLE" not in os.environ and "OCTAVE" in os.environ:
             os.environ["OCTAVE_EXECUTABLE"] = os.environ["OCTAVE"]
 
+        # Preserve the SIGINT handler across engine startup.  The underlying
+        # pexpect spawn temporarily replaces SIGINT with SIG_DFL so that the
+        # Octave child process inherits a clean disposition.  If a concurrent
+        # thread (e.g. from a scipy/sympy lazy initialiser) transiently sets
+        # SIGINT to SIG_IGN at exactly the wrong moment, pexpect's finally
+        # block can "restore" that transient SIG_IGN value, leaving SIGINT
+        # permanently ignored for the rest of the Python process (issue #168).
+        # Restoring the handler we observed before the spawn prevents engine
+        # startup from having any net effect on the caller's SIGINT disposition.
+        _saved_sigint = None
+        if threading.current_thread() is threading.main_thread():
+            with contextlib.suppress(Exception):
+                _saved_sigint = signal.getsignal(signal.SIGINT)
+
         try:
             # Pass --no-line-editing to avoid readline overhead on every function
             # call in Octave 7+. In interactive mode, readline does expensive
@@ -756,6 +772,10 @@ class Oct2Py:
             )
         except Exception as e:
             raise Oct2PyError(str(e)) from None
+        finally:
+            if _saved_sigint is not None:
+                with contextlib.suppress(Exception):
+                    signal.signal(signal.SIGINT, _saved_sigint)
 
         # Set up the temp directory for MAT file exchange.
         if self.temp_dir is None:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,7 @@ import glob
 import logging
 import os
 import shutil
+import signal
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -550,3 +551,38 @@ class TestMisc:
             stream_handler=lines.append,
         )
         assert any("hello_from_oct2py" in line for line in lines)
+
+    def test_restart_preserves_sigint_handler(self):
+        """restart() must not permanently alter the SIGINT disposition (issue #168).
+
+        If a third-party library (e.g. an older scipy/sympy) transiently sets
+        SIGINT to SIG_IGN and the pexpect spawn captures that transient value,
+        the spawn's finally block can "restore" SIG_IGN after the library has
+        already corrected it.  Oct2Py's restart() must restore whatever handler
+        was in place before the spawn so that it has no net effect on SIGINT.
+        """
+        original = signal.getsignal(signal.SIGINT)
+        try:
+            # Simulate a library that leaves SIGINT=SIG_IGN before Oct2Py starts.
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            oc = Oct2Py()
+            oc.exit()
+            assert signal.getsignal(signal.SIGINT) is signal.SIG_IGN
+        finally:
+            signal.signal(signal.SIGINT, original)
+
+    def test_restart_preserves_custom_sigint_handler(self):
+        """restart() restores a custom SIGINT handler unchanged (issue #168)."""
+        original = signal.getsignal(signal.SIGINT)
+        sentinel = []
+
+        def custom_handler(signum, frame):  # pragma: no cover
+            sentinel.append(signum)
+
+        try:
+            signal.signal(signal.SIGINT, custom_handler)
+            oc = Oct2Py()
+            oc.exit()
+            assert signal.getsignal(signal.SIGINT) is custom_handler
+        finally:
+            signal.signal(signal.SIGINT, original)


### PR DESCRIPTION
## References

Closes #168

## Description

When a third-party library (e.g. older scipy ≤ 1.1, imported transitively via sympy) transiently sets `SIGINT` to `SIG_IGN` during its own subprocess/pool setup, there is a race with `pexpect`'s spawn code inside `metakernel`:

```python
sig = signal.signal(signal.SIGINT, signal.SIG_DFL)  # saves current handler
child = pty_spawn(...)                               # slow — race window here
finally:
    if sig:
        signal.signal(signal.SIGINT, sig)            # "restores" whatever was saved
```

If the transient `SIG_IGN` is in place at the exact moment `signal.signal()` runs, pexpect saves `SIG_IGN` as `sig`. Even after the other library correctly restores the handler, pexpect's `finally` block overwrites that correction — leaving `SIGINT` permanently ignored for the rest of the Python process.

## Changes

- `oct2py/core.py` — In `restart()`, save the SIGINT handler before `OctaveEngine()` starts and restore it unconditionally in a `finally` block, ensuring engine startup has no net effect on the caller's signal disposition.
- `tests/test_misc.py` — Two new tests covering `SIG_IGN` and custom-handler preservation across `restart()`.

## Backwards-incompatible changes

None

## Testing

```
just test tests/test_misc.py::TestMisc::test_restart_preserves_sigint_handler
just test tests/test_misc.py::TestMisc::test_restart_preserves_custom_sigint_handler
just test
```

All 178 tests pass.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code