### PR TITLE
Document plot-rendering limitation for .m files and add regression test

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -431,6 +431,18 @@ class Oct2Py:
         Python. That is, all values must be passed as a comma separated list,
         not using `x=foo` assignment.
 
+        **Plot rendering limitation (issue #172):** oct2py executes Octave
+        synchronously, so figure updates triggered by ``pause()`` calls inside
+        a ``.m`` function are not rendered mid-execution — plots are only
+        exposed after the entire function returns.  For interactive display
+        this means figures appear at the end of the call, not incrementally.
+        To capture figures from inside a ``.m`` file programmatically, pass
+        ``plot_dir`` and then call :meth:`extract_figures`::
+
+            plot_dir = tempfile.mkdtemp()
+            octave.feval("my_func.m", plot_dir=plot_dir)
+            imgs = octave.extract_figures(plot_dir)
+
         Examples
         --------
         >>> from oct2py import octave
@@ -974,8 +986,8 @@ class Oct2Py:
         doc += "Keyword arguments to dynamic functions are deprecated.\n"
         doc += "The `plot_*` kwargs will be ignored, but the rest will\n"
         doc += "used as key - value pairs as in version 3.x.\n"
-        doc += "Use `set_plot_settings()` for plot settings, and use\n"
-        doc += "`func_args` directly for key - value pairs."
+        doc += "Pass `plot_dir` to `feval` or `eval` for inline plot capture,\n"
+        doc += "and use `func_args` directly for key - value pairs."
         return doc
 
     def _exist(self, name):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -212,6 +212,32 @@ class TestMisc:
         assert glob.glob("%s/*" % plot_dir)
         assert self.oc.extract_figures(plot_dir)
 
+    def test_plot_from_inside_m_file(self):
+        """Test that plots generated inside a .m function are captured via plot_dir (issue #172).
+
+        When a .m file creates figures internally (e.g. clf/subplot/plot/pause),
+        passing plot_dir to feval should save those figures even though the
+        rendering happens inside the Octave subprocess.
+        """
+        plot_dir = tempfile.mkdtemp().replace("\\", "/")
+        m_path = os.path.join(tempfile.gettempdir(), "test_plot_inside.m")
+        with open(m_path, "w") as f:
+            f.write(
+                "function test_plot_inside()\n"
+                "  clf;\n"
+                "  subplot(2,1,1);\n"
+                "  plot([1 2 3], [4 5 6]);\n"
+                "  subplot(2,1,2);\n"
+                "  plot([1 2 3], [6 5 4]);\n"
+                "end\n"
+            )
+        try:
+            self.oc.feval(m_path, nout=0, plot_dir=plot_dir)
+            assert glob.glob("%s/*" % plot_dir), "No figure files saved from inside .m function"
+            assert self.oc.extract_figures(plot_dir), "extract_figures returned nothing"
+        finally:
+            os.unlink(m_path)
+
     def test_interactive_figure(self):
         """Test that figures are created and accessible with a non-inline backend (issue #176).
 


### PR DESCRIPTION
## References

Closes #172

## Description

Issue #172 reported that plots called inside a `.m` function via `feval` are never rendered. After investigation, the core behavior is correct — figures **are** captured when `plot_dir` is passed — but the limitation was undocumented and untested.

The fundamental constraint is architectural: oct2py executes Octave synchronously, so `pause()` calls inside a `.m` function do not trigger mid-execution rendering. Figures are only exposed after the full function returns.

## Changes

- **`oct2py/core.py`**: Added a `Notes` section to the `feval` docstring explaining the plot-rendering limitation and showing the `plot_dir` + `extract_figures` workaround with a code example. Also fixed a stale reference to the long-removed `set_plot_settings()` method.
- **`tests/test_misc.py`**: Added `test_plot_from_inside_m_file` to verify that figures created internally by a `.m` function (`clf`/`subplot`/`plot`) are properly captured when `plot_dir` is passed to `feval`.

## Backwards-incompatible changes

None

## Testing

New test `TestMisc::test_plot_from_inside_m_file` passes. Full suite: 179 passed, 4 skipped, 2 xfailed.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code