### PR TITLE
Add expr=True support to get_pointer (closes #169)

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -66,6 +66,31 @@ array([[1., 2., 3.]])
 This is equivalent to using `push` and `pull` directly, but can be more
 natural when porting code from MATLAB's Python engine.
 
+## Expression Pointers
+
+Some Octave values — such as cell arrays of function handles — cannot be
+converted to Python objects. Use `get_pointer` with `expr=True` to hold a
+reference to such an expression and pass it directly to Octave functions
+without a round-trip through Python:
+
+```pycon
+>>> from oct2py import octave
+>>> ptr = octave.get_pointer('{@cos @sin}', expr=True)
+>>> type(ptr).__name__
+'OctaveVariablePtr'
+>>> # Pass the cell of function handles to an Octave function unchanged
+>>> octave.feval('cellfun', '@(f) f(0)', ptr)  # doctest: +SKIP
+array([1., 0.])
+```
+
+`get_pointer(expr_str, expr=True)` assigns the expression to a uniquely
+named temporary variable in the Octave workspace and returns a pointer to
+it. The pointer's `address` is the internal variable name; the temporary
+variable persists for the life of the session.
+
+This is different from `get_pointer(name)` (without `expr=True`), which
+looks up an *existing* named variable or function.
+
 ## Using M-Files
 
 In order to use an m-file in Oct2Py you must first call `addpath` for

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -11,6 +11,7 @@ import shutil
 import signal
 import tempfile
 import threading
+import uuid
 import warnings
 import weakref
 
@@ -297,15 +298,26 @@ class Oct2Py:
             return outputs[0]
         return outputs
 
-    def get_pointer(self, name, timeout=None):
+    def get_pointer(self, name, timeout=None, expr=False):
         """Get a pointer to a named object in the Octave workspace.
 
         Parameters
         ----------
         name: str
-            The name of the object in the Octave workspace.
+            The name of the object in the Octave workspace, or an Octave
+            expression string when ``expr=True``.
         timeout: float, optional.
             Time to wait for response from Octave (per line).
+        expr: bool, optional (default False)
+            If True, treat `name` as an Octave expression string rather than a
+            variable name. The expression is assigned to a unique temporary
+            variable in the Octave workspace and a pointer to that variable is
+            returned. Use this when you need to pass an expression that cannot
+            be converted to a Python object (e.g. cell arrays of function
+            handles like ``{@cos @sin}``).
+
+            Note: the temporary variable persists in the Octave workspace for
+            the lifetime of the session.
 
         Examples
         --------
@@ -328,6 +340,13 @@ class Oct2Py:
         >>> x
         2.0
 
+        >>> from oct2py import octave
+        >>> ptr = octave.get_pointer('{@cos @sin}', expr=True)
+        >>> type(ptr).__name__
+        'OctaveVariablePtr'
+        >>> # Pass the cell of function handles to an Octave function
+        >>> octave.feval('cellfun', '@(f) f(0)', ptr)  # doctest: +SKIP
+
         Notes
         -----
         Pointers can be passed to `feval` or dynamic functions as function
@@ -344,6 +363,11 @@ class Oct2Py:
         -------
         A variable, object, user class, or function pointer as appropriate.
         """
+        if expr:
+            tmp_name = f"_oct2py_expr_{uuid.uuid4().hex}"
+            self.eval(f"{tmp_name} = {name}", timeout=timeout)
+            return _make_variable_ptr_instance(self, tmp_name)
+
         exist = self._exist(name)
         isobject = self._isobject(name, exist)
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -256,6 +256,20 @@ class TestUsage:
         with pytest.raises(Oct2PyError):
             self.oc.get_pointer("foo123")
 
+        # expr=True: treat argument as an Octave expression
+        eptr = self.oc.get_pointer("{@cos @sin}", expr=True)
+        assert type(eptr).__name__ == "OctaveVariablePtr"
+        assert eptr.address.startswith("_oct2py_expr_")
+
+        # Each call produces a unique temp var
+        eptr2 = self.oc.get_pointer("{@cos @sin}", expr=True)
+        assert eptr.address != eptr2.address
+
+        # The pointer can be passed to an Octave function
+        fptr = self.oc.get_pointer("@(f) f(0)", expr=True)
+        result = self.oc.feval("cellfun", fptr, eptr)
+        assert np.allclose(result, [1.0, 0.0])
+
     def test_get_max_nout(self):
         self.oc.addpath(os.path.realpath(os.path.dirname(__file__)))
         here = os.path.dirname(__file__)


### PR DESCRIPTION
## Summary

- Adds `expr=True` parameter to `get_pointer`, allowing an Octave expression string to be assigned to a unique temp variable and returned as an `OctaveVariablePtr`
- Enables cell arrays of function handles (e.g. `{@cos @sin}`) and other values that can't round-trip through Python to be passed directly to Octave functions
- Documents the feature in `docs/info.md` under a new "Expression Pointers" section

Closes #169

## Test plan

- [x] `test_get_pointer` passes with new `expr=True` assertions (type, unique address prefix, uniqueness per call, feval round-trip)
- [x] Existing `get_pointer` behaviour (variable, function, user class pointers) unchanged