### PR TITLE
Fix logging configuration to follow Python library best practices

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -177,15 +177,49 @@ version of Octave.
 
 ## Logging
 
-Oct2Py supports logging of session interaction. You can provide a logger
-to the constructor or set one at any time.
+Oct2Py uses the standard Python `logging` module under the logger name
+`"oct2py"`. Following Python library best practices, no handlers or levels
+are configured by default — all log output is suppressed unless your
+application sets up logging.
+
+To see oct2py log output, configure the `"oct2py"` logger (or the root
+logger) in your application:
+
+```python
+import logging
+
+# Show INFO and above from oct2py
+logging.getLogger("oct2py").setLevel(logging.INFO)
+logging.getLogger("oct2py").addHandler(logging.StreamHandler())
+
+# Or configure the root logger (affects all loggers):
+logging.basicConfig(level=logging.INFO)
+```
+
+To enable DEBUG output (useful for troubleshooting), use `logging.DEBUG`:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+When using pytest, pass `--log-cli-level=DEBUG` on the command line or add
+to `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "DEBUG"
+```
+
+You can also pass a logger directly to the `Oct2Py` constructor or replace
+it at any time:
 
 ```pycon
 >>> import logging
 >>> from oct2py import Oct2Py, get_log
 >>> oc = Oct2Py(logger=get_log())
 >>> oc.logger = get_log("new_log")
->>> oc.logger.setLevel(logging.INFO)
 ```
 
 All Oct2Py methods support a `verbose` keyword. If True, the commands

--- a/oct2py/utils.py
+++ b/oct2py/utils.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of the MIT License.
 
 import logging
-import sys
 
 
 class Oct2PyError(Exception):
@@ -13,7 +12,7 @@ class Oct2PyError(Exception):
 
 
 def get_log(name=None):
-    """Return a console logger.
+    """Return a logger for oct2py.
 
     Output may be sent to the logger using the `debug`, `info`, `warning`,
     `error` and `critical` methods.
@@ -29,23 +28,10 @@ def get_log(name=None):
         The logger object.
     """
     name = "oct2py" if name is None else "oct2py." + name
-
-    log = logging.getLogger(name)
-    log.setLevel(logging.INFO)
-    return log
+    return logging.getLogger(name)
 
 
-def _setup_log():
-    """Configure root logger."""
-    try:
-        handler = logging.StreamHandler(stream=sys.stdout)
-    except TypeError:  # pragma: no cover
-        handler = logging.StreamHandler(strm=sys.stdout)  # type:ignore[call-overload]
-
-    log = get_log()
-    log.addHandler(handler)
-    log.setLevel(logging.INFO)
-    log.propagate = False
-
-
-_setup_log()
+# Add a NullHandler so that log records are silently discarded unless the
+# application configures logging.  Per Python logging best practices, libraries
+# must not install their own handlers or set levels on their loggers.
+logging.getLogger("oct2py").addHandler(logging.NullHandler())


### PR DESCRIPTION
## References

Closes #162

## Description

oct2py was installing its own `StreamHandler` on the `"oct2py"` logger and
forcing the level to `INFO`, which prevented applications (and pytest's
`--log-cli-level`) from controlling oct2py log output. This violates the
[Python logging library guidelines](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).

## Changes

- Removed `_setup_log()` and the `setLevel(logging.INFO)` call in `get_log()`
- Replaced with a single `NullHandler` on the root `"oct2py"` logger
- Removed now-unused `import sys`
- Expanded the Logging section in `docs/info.md` to document how users can configure the logger (via `basicConfig`, direct handler setup, or pytest options)

## Backwards-incompatible changes

oct2py no longer emits log output by default. Applications that relied on
the automatic `StreamHandler` will need to configure logging themselves
(e.g. `logging.basicConfig(level=logging.INFO)`). The docs now explain how.

## Testing

All 180 existing tests pass.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code