### PR TITLE
Fix Python bool → Octave logical conversion (closes #153)

### DIFF
--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -338,6 +338,11 @@ def _encode(data, convert_to_float):  # noqa
             out[name] = _encode(view[name], ctf)
         return out
 
+    # Boolean objects should be preserved as logical
+    # (bool is a subclass of int in Python, so this must come first)
+    if isinstance(data, bool):
+        return np.bool_(data)
+
     # Integer objects should be converted to floats
     if isinstance(data, int):
         return float(data)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -129,6 +129,11 @@ class TestConversions:
             x_ = self.oc.pull("x")
             assert np.allclose(np.atleast_2d(np.shape(x_)), self.oc.eval("size(x)", verbose=False))
 
+    def test_bool_islogical(self):
+        """Test that Python bools are passed to Octave as logical type"""
+        assert self.oc.islogical(False) == 1
+        assert self.oc.islogical(True) == 1
+
     def test_python_conversions(self):
         """Test roundtrip python type conversions"""
         self.oc.addpath(os.path.dirname(__file__))


### PR DESCRIPTION
## Summary

Fixes #153

- `octave.islogical(False)` was returning `0` instead of `1` because `bool` is a subclass of `int` in Python, causing the `isinstance(data, int)` check in `_encode()` to catch booleans and convert them to `float`
- Added an explicit `bool` check before the `int` check in `oct2py/io.py`, converting Python bools to `np.bool_` which scipy serializes as `mxLOGICAL_CLASS`

## Test plan

- [x] `TestConversions::test_bool_islogical` — directly asserts `octave.islogical(False) == 1` and `octave.islogical(True) == 1`
- [x] `TestConversions::test_python_conversions` — existing roundtrip test covering `(bool, "logical", bool)` continues to pass