### PR TITLE
Add backend='disable' to suppress all figure rendering

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -143,7 +143,9 @@ class Oct2Py:
     convert_to_float : bool, optional
         If true, convert integer types to float when passing to Octave.
     backend: string, optional
-        The graphics_toolkit to use for plotting.
+        The graphics_toolkit to use for plotting.  Use ``"disable"`` to
+        suppress all figure rendering (useful in headless or
+        computation-only environments where a display is unavailable).
     keep_matlab_shapes: bool, optional
         If true, matlab shapes will be preserved (scalars as (1,1) etc)
     auto_show : bool, optional
@@ -169,7 +171,7 @@ class Oct2Py:
         self._logger = None
         self.logger = logger
         self.timeout = timeout
-        self.backend = backend or "default"
+        self.backend = backend if backend is not None else "default"
         self.keep_matlab_shapes = keep_matlab_shapes
         self.temp_dir = temp_dir
         self._temp_dir_owner = False
@@ -178,6 +180,8 @@ class Oct2Py:
         self._function_ptrs = {}
         if auto_show is None:
             auto_show = bool(os.environ.get("PYCHARM_HOSTED"))
+            if self.backend == "disable":
+                auto_show = False
         self._auto_show = auto_show
         _instances.add(self)
         self.restart()
@@ -444,6 +448,8 @@ class Oct2Py:
         """Capture open Octave figures and display them via matplotlib."""
         if not self._engine:
             return
+        if self.backend == "disable":
+            return
         try:
             import matplotlib.image as mpimg  # noqa: PLC0415
             import matplotlib.pyplot as plt  # noqa: PLC0415
@@ -580,6 +586,9 @@ class Oct2Py:
         # Choose appropriate plot backend.
         default_backend = "inline" if plot_dir else self.backend
         backend = kwargs.get("plot_backend", default_backend)
+        # Map "disable" to "inline" so octave_kernel sets defaultfigurevisible=off.
+        if backend == "disable":
+            backend = "inline"
 
         settings = dict(
             backend=backend,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -368,6 +368,8 @@ class TestMisc:
 
     def test_disable_backend(self):
         """backend='disable' suppresses all figure rendering (issue #152)."""
+        if self._flatpak:
+            pytest.skip("not supported inside flatpak sandbox")
         from unittest.mock import patch
 
         oc = Oct2Py(backend="disable")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -366,6 +366,29 @@ class TestMisc:
         oc.exit()  # sets _engine = None
         oc._show_figures()  # must return silently without error
 
+    def test_disable_backend(self):
+        """backend='disable' suppresses all figure rendering (issue #152)."""
+        from unittest.mock import patch
+
+        oc = Oct2Py(backend="disable")
+        try:
+            # Basic computation must still work.
+            result = oc.eval("1 + 1", nout=1)
+            assert result == 2
+
+            # auto_show must default to False.
+            assert not oc._auto_show
+
+            # make_figures must never be called when backend='disable'.
+            with patch.object(oc._engine, "make_figures") as mock_mf:
+                oc.eval("figure(1); plot([1,2,3]);", nout=0)
+                mock_mf.assert_not_called()
+
+            # show() must be a silent no-op.
+            oc.show()
+        finally:
+            oc.exit()
+
     def test_narg_out(self):
         if self._flatpak:
             pytest.skip("Flatpak version of octave does not handle svd")


### PR DESCRIPTION
## References

Closes #152

## Description

Adds support for `backend="disable"` when constructing an `Oct2Py` session. This suppresses all figure rendering, making oct2py usable in headless or computation-only environments where a display or gnuplot is unavailable.

## Changes

- `core.py`: Preserve `"disable"` string in `__init__` rather than coercing to `"default"`; force `auto_show=False` when `backend="disable"`; map `"disable"` to `"inline"` when setting `plot_settings` (reuses the existing `octave_kernel` path that applies `defaultfigurevisible=off`); add early-return guard in `_show_figures` so `show()` is a safe no-op
- `tests/test_misc.py`: New `test_disable_backend` regression test

## Backwards-incompatible changes

None

## Testing

New test `TestMisc::test_disable_backend` verifies:
- Computation works normally with `backend="disable"`
- `_auto_show` defaults to `False`
- `make_figures` is never called after a `plot()` call
- `show()` is a silent no-op

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code