### PR TITLE
Fix Octave startup crash when opencv-python is imported on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Run example notebook
         run: just test-notebook
       - name: Test opencv compatibility
+        if: ${{ matrix.python-version != '3.14t' }}
         run: just test-opencv
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
         run: just cover
       - name: Run example notebook
         run: just test-notebook
+      - name: Test opencv compatibility
+        run: just test-opencv
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
@@ -71,6 +73,8 @@ jobs:
           install-type: ${{ matrix.install-type }}
       - name: Run tests
         run: just test tests/test_usage.py tests/test_misc.py
+      - name: Test opencv compatibility
+        run: just test-opencv
 
   benchmark:
     runs-on: ubuntu-24.04

--- a/justfile
+++ b/justfile
@@ -51,6 +51,10 @@ benchmark-compare:
     uv run --group bench asv machine --yes
     uv run --group bench asv continuous $(git merge-base HEAD origin/main) HEAD --show-stderr
 
+# Test opencv/oct2py compatibility
+test-opencv:
+    uv run --with "oct2py @ ." --with opencv-python scripts/test-opencv.py
+
 # Run a pre-commit target
 pre-commit *args:
     uv tool run prek --all-files {{args}}

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -859,6 +859,7 @@ class Oct2Py:
             with contextlib.suppress(Exception):
                 _saved_sigint = signal.getsignal(signal.SIGINT)
 
+        _qt_plugin_path = None
         try:
             # Pass --no-line-editing to avoid readline overhead on every function
             # call in Octave 7+. In interactive mode, readline does expensive
@@ -870,6 +871,13 @@ class Oct2Py:
             # registration) does not hold a strong reference back to this Oct2Py
             # instance, which would otherwise prevent __del__ / exit() from ever
             # being called and cause Octave subprocesses to accumulate.
+            #
+            # Strip QT_QPA_PLATFORM_PLUGIN_PATH before spawning Octave.  When
+            # opencv-python is imported it injects its own bundled Qt plugin
+            # directory into this variable; pexpect inherits os.environ, so the
+            # Octave child process would pick up the incompatible path and crash
+            # with "Could not load the Qt platform plugin" (issue #240).
+            _qt_plugin_path = os.environ.pop("QT_QPA_PLATFORM_PLUGIN_PATH", None)
             _weak_self = weakref.ref(self)
 
             def _stdin_handler(line):
@@ -889,6 +897,8 @@ class Oct2Py:
             if _saved_sigint is not None:
                 with contextlib.suppress(Exception):
                     signal.signal(signal.SIGINT, _saved_sigint)
+            if _qt_plugin_path is not None:
+                os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = _qt_plugin_path
 
         # Set up the temp directory for MAT file exchange.
         if self.temp_dir is None:

--- a/scripts/test-opencv.py
+++ b/scripts/test-opencv.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env -S uv run
+# /// script
+# dependencies = ["opencv-python"]
+# ///
+"""Repro script for issue #240: conflict between opencv-python and oct2py.
+
+When cv2 is imported before Oct2Py() is instantiated on Linux, Octave
+crashes with pexpect.exceptions.EOF due to a Qt platform plugin conflict.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+CASES = [
+    (
+        "cv2 imported before Oct2Py()",
+        textwrap.dedent("""\
+            import cv2
+            from oct2py import Oct2Py
+            oc = Oct2Py()
+            result = oc.eval("1 + 1", verbose=False)
+            oc.exit()
+            assert result == 2
+        """),
+    ),
+    (
+        "cv2 imported after oct2py module, before Oct2Py()",
+        textwrap.dedent("""\
+            from oct2py import Oct2Py
+            import cv2
+            oc = Oct2Py()
+            result = oc.eval("1 + 1", verbose=False)
+            oc.exit()
+            assert result == 2
+        """),
+    ),
+]
+
+failures = []
+for name, code in CASES:
+    print(f"Case: {name} ... ", end="", flush=True)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        print("PASS")
+    else:
+        print("FAIL")
+        print(f"  stdout: {result.stdout.strip()}")
+        print(f"  stderr: {result.stderr.strip()}")
+        failures.append(name)
+
+if failures:
+    print(f"\n{len(failures)} case(s) failed.")
+    sys.exit(1)
+else:
+    print("\nAll cases passed.")

--- a/scripts/test-opencv.py
+++ b/scripts/test-opencv.py
@@ -36,22 +36,23 @@ CASES = [
 
 failures = []
 for name, code in CASES:
-    print(f"Case: {name} ... ", end="", flush=True)
-    result = subprocess.run(
+    print(f"Case: {name} ... ", end="", flush=True)  # noqa: T201
+    result = subprocess.run(  # noqa: S603
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode == 0:
-        print("PASS")
+        print("PASS")  # noqa: T201
     else:
-        print("FAIL")
-        print(f"  stdout: {result.stdout.strip()}")
-        print(f"  stderr: {result.stderr.strip()}")
+        print("FAIL")  # noqa: T201
+        print(f"  stdout: {result.stdout.strip()}")  # noqa: T201
+        print(f"  stderr: {result.stderr.strip()}")  # noqa: T201
         failures.append(name)
 
 if failures:
-    print(f"\n{len(failures)} case(s) failed.")
+    print(f"\n{len(failures)} case(s) failed.")  # noqa: T201
     sys.exit(1)
 else:
-    print("\nAll cases passed.")
+    print("\nAll cases passed.")  # noqa: T201

--- a/scripts/test-opencv.py
+++ b/scripts/test-opencv.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env -S uv run
-# /// script
-# dependencies = ["opencv-python"]
-# ///
-"""Repro script for issue #240: conflict between opencv-python and oct2py.
+#!/usr/bin/env python
+"""Regression test for issue #240: conflict between opencv-python and oct2py.
 
-When cv2 is imported before Oct2Py() is instantiated on Linux, Octave
-crashes with pexpect.exceptions.EOF due to a Qt platform plugin conflict.
+Validates that importing cv2 before or after oct2py no longer causes Octave
+to crash with pexpect.exceptions.EOF due to a Qt platform plugin conflict.
 """
 
 import subprocess


### PR DESCRIPTION
Closes #240.

## Summary

When `opencv-python` is imported before `Oct2Py()` is instantiated on Linux,
Octave crashes at startup with `pexpect.exceptions.EOF`. The root cause is
that `cv2` injects its bundled Qt plugin directory into
`QT_QPA_PLATFORM_PLUGIN_PATH`; since oct2py uses pexpect to spawn Octave,
the child process inherits this path and fails to load its own Qt platform
plugin.

- Fixes `oct2py/core.py`: temporarily pops `QT_QPA_PLATFORM_PLUGIN_PATH`
  from `os.environ` before spawning the Octave subprocess, then restores it
  in the `finally` block
- Adds `scripts/test-opencv.py` — a regression test that exercises both
  import orderings (`cv2` before and after the oct2py module)
- Adds a `test-opencv` justfile recipe for easy local reproduction
- Runs `just test-opencv` in both the `test` and `test-other` CI jobs