### PR TITLE
Fix system() failures on Windows — augment PATH with Octave's MinGW/MSYS tool dirs

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -27,7 +27,7 @@ from .dynamic import (
     _make_variable_ptr_instance,
 )
 from .io import Cell, StructArray, read_file, write_file
-from .utils import Oct2PyError, get_log
+from .utils import Oct2PyError, _augment_path_for_windows, get_log
 
 HERE = osp.realpath(osp.dirname(__file__))
 
@@ -842,8 +842,10 @@ class Oct2Py:
         if self._engine:
             self._engine.repl.terminate()
 
-        if "OCTAVE_EXECUTABLE" not in os.environ and "OCTAVE" in os.environ:
-            os.environ["OCTAVE_EXECUTABLE"] = os.environ["OCTAVE"]
+        # OctaveEngine resolves OCTAVE_EXECUTABLE from its env; honour the
+        # legacy OCTAVE alias by passing it explicitly when OCTAVE_EXECUTABLE
+        # is absent.
+        _executable = os.environ.get("OCTAVE_EXECUTABLE") or os.environ.get("OCTAVE", "")
 
         # Preserve the SIGINT handler across engine startup.  The underlying
         # pexpect spawn temporarily replaces SIGINT with SIG_DFL so that the
@@ -879,6 +881,7 @@ class Oct2Py:
                 return None
 
             self._engine = OctaveEngine(
+                executable=_executable,
                 stdin_handler=_stdin_handler,
                 logger=self.logger,
                 cli_options="--no-line-editing",
@@ -889,6 +892,8 @@ class Oct2Py:
             if _saved_sigint is not None:
                 with contextlib.suppress(Exception):
                     signal.signal(signal.SIGINT, _saved_sigint)
+
+        _augment_path_for_windows(self._engine.executable)
 
         # Set up the temp directory for MAT file exchange.
         if self.temp_dir is None:

--- a/oct2py/utils.py
+++ b/oct2py/utils.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the MIT License.
 
 import logging
+import os
 
 
 class Oct2PyError(Exception):
@@ -35,3 +36,40 @@ def get_log(name=None):
 # application configures logging.  Per Python logging best practices, libraries
 # must not install their own handlers or set levels on their loggers.
 logging.getLogger("oct2py").addHandler(logging.NullHandler())
+
+
+def _augment_path_for_windows(executable: str) -> None:
+    """On Windows, prepend Octave's bundled MinGW/MSYS tool dirs to PATH.
+
+    The Octave GUI launcher adds <install>/mingw64/bin and <install>/usr/bin
+    to PATH before starting octave-cli, providing Unix commands like ``cat``.
+    When oct2py spawns octave-cli directly those directories are missing.
+    This function detects them from the resolved executable path and prepends
+    them so the subprocess inherits the same environment.
+    """
+    if os.name != "nt":
+        return
+
+    if not executable:
+        return
+
+    executable = os.path.realpath(executable)
+    exe_dir = os.path.dirname(executable)
+    # Standard installer: <root>/mingw64/bin/octave-cli.exe  → root = grandparent
+    # Portable layout:    <root>/bin/octave-cli.exe          → root = parent
+    parent = os.path.dirname(exe_dir)
+    grandparent = os.path.dirname(parent)
+
+    current_path = os.environ.get("PATH", "")
+    lower_set = {p.lower() for p in current_path.split(os.pathsep)}
+    new_entries: list[str] = []
+
+    for root in (grandparent, parent):
+        for sub in (os.path.join("mingw64", "bin"), os.path.join("usr", "bin")):
+            tool_dir = os.path.join(root, sub)
+            if os.path.isdir(tool_dir) and tool_dir.lower() not in lower_set:
+                new_entries.append(tool_dir)
+                lower_set.add(tool_dir.lower())
+
+    if new_entries:
+        os.environ["PATH"] = os.pathsep.join(new_entries) + os.pathsep + current_path

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -157,21 +157,22 @@ class TestRestart:
         oc.exit()
 
     def test_restart_octave_env_var_propagation(self):
-        """OCTAVE env var should be copied to OCTAVE_EXECUTABLE if not already set."""
+        """OCTAVE env var should be passed to OctaveEngine when OCTAVE_EXECUTABLE is unset."""
         env_without_exec = {k: v for k, v in os.environ.items() if k != "OCTAVE_EXECUTABLE"}
         env_without_exec["OCTAVE"] = "/fake/octave"
         fake_engine = MagicMock()
         fake_engine.tmp_dir = tempfile.mkdtemp()
         with (
             patch.dict(os.environ, env_without_exec, clear=True),
-            patch("oct2py.core.OctaveEngine", return_value=fake_engine),
+            patch("oct2py.core.OctaveEngine", return_value=fake_engine) as mock_engine,
         ):
             oc = Oct2Py()
-            assert os.environ.get("OCTAVE_EXECUTABLE") == "/fake/octave"
+            assert mock_engine.call_args.kwargs.get("executable") == "/fake/octave"
+            assert "OCTAVE_EXECUTABLE" not in os.environ
             oc.exit()
 
     def test_restart_octave_executable_not_overwritten(self):
-        """OCTAVE_EXECUTABLE should not be overwritten if already set."""
+        """OCTAVE_EXECUTABLE should take precedence over OCTAVE when passed to OctaveEngine."""
         env = dict(os.environ)
         env["OCTAVE_EXECUTABLE"] = "/custom/octave"
         env["OCTAVE"] = "/other/octave"
@@ -179,10 +180,10 @@ class TestRestart:
         fake_engine.tmp_dir = tempfile.mkdtemp()
         with (
             patch.dict(os.environ, env, clear=True),
-            patch("oct2py.core.OctaveEngine", return_value=fake_engine),
+            patch("oct2py.core.OctaveEngine", return_value=fake_engine) as mock_engine,
         ):
             oc = Oct2Py()
-            assert os.environ.get("OCTAVE_EXECUTABLE") == "/custom/octave"
+            assert mock_engine.call_args.kwargs.get("executable") == "/custom/octave"
             oc.exit()
 
     def test_restart_engine_creation_failure_raises(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -780,3 +780,67 @@ class TestMisc:
         # The result should be coerced to a dict-like Struct (or similar
         # mapping) containing the state-space matrices.
         assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests for _augment_path_for_windows (issue #228)
+# ---------------------------------------------------------------------------
+
+from oct2py.utils import _augment_path_for_windows  # noqa: E402
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only behaviour")
+def test_augment_path_adds_mingw_dirs(tmp_path, monkeypatch):
+    """Helper prepends <root>/mingw64/bin and <root>/usr/bin on Windows."""
+    # Build a fake Octave install tree: <root>/mingw64/bin/octave-cli.exe
+    exe_dir = tmp_path / "mingw64" / "bin"
+    exe_dir.mkdir(parents=True)
+    exe = exe_dir / "octave-cli.exe"
+    exe.touch()
+
+    mingw_bin = str(tmp_path / "mingw64" / "bin")
+    usr_bin_dir = tmp_path / "usr" / "bin"
+    usr_bin_dir.mkdir(parents=True)
+    usr_bin = str(usr_bin_dir)
+
+    monkeypatch.setenv("PATH", "C:\\Windows\\System32")
+
+    _augment_path_for_windows(str(exe))
+
+    path_entries = os.environ["PATH"].split(os.pathsep)
+    assert mingw_bin in path_entries
+    assert usr_bin in path_entries
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only behaviour")
+def test_augment_path_idempotent(tmp_path, monkeypatch):
+    """Calling the helper twice must not duplicate PATH entries."""
+    exe_dir = tmp_path / "mingw64" / "bin"
+    exe_dir.mkdir(parents=True)
+    exe = exe_dir / "octave-cli.exe"
+    exe.touch()
+    (tmp_path / "usr" / "bin").mkdir(parents=True)
+
+    monkeypatch.setenv("PATH", "C:\\Windows\\System32")
+
+    _augment_path_for_windows(str(exe))
+    path_after_first = os.environ["PATH"]
+    _augment_path_for_windows(str(exe))
+    path_after_second = os.environ["PATH"]
+
+    assert path_after_first == path_after_second
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Non-Windows behaviour")
+def test_augment_path_noop_on_non_windows(monkeypatch):
+    """Helper must leave PATH unchanged on non-Windows platforms."""
+    original_path = os.environ.get("PATH", "")
+    _augment_path_for_windows("octave-cli")
+    assert os.environ.get("PATH", "") == original_path
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows integration test")
+def test_system_cat_works_via_oct2py():
+    """Oct2Py session can call system('cat --version') without raising."""
+    with Oct2Py() as oc:
+        oc.eval("[~, out] = system('cat --version');", nout=0)


### PR DESCRIPTION
## References

Closes #228

## Description

On Windows, oct2py spawns `octave-cli` directly and the subprocess inherits Python's `PATH`, which lacks the MinGW/MSYS bin dirs that the Octave GUI launcher normally prepends. This causes `system("cat ...")` and similar Unix-tool calls to silently fail.

## Changes

- Add `_augment_path_for_windows(executable: str)` in `oct2py/utils.py` that detects `<install>/mingw64/bin` and `<install>/usr/bin` from the engine's resolved executable path and prepends them to `os.environ["PATH"]` (idempotent; no-op on non-Windows).
- In `Oct2Py.restart()`: stop mutating `os.environ["OCTAVE_EXECUTABLE"]` as an alias for `OCTAVE`; instead resolve the executable locally and pass it directly to `OctaveEngine(executable=...)`. Call `_augment_path_for_windows(self._engine.executable)` after engine construction.
- Add four tests in `tests/test_misc.py` (Windows-specific tests skip on macOS/Linux).

## Backwards-incompatible changes

None

## Testing

- `just lint` — passes
- `just test tests/test_misc.py` — 51 passed, 5 skipped (Windows-specific tests correctly skipped on macOS/Linux)

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code