### PR TITLE
Support Octave package namespace access (closes #286)

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -21,8 +21,10 @@ from metakernel.pexpect import EOF, TIMEOUT
 from octave_kernel.kernel import STDIN_PROMPT, OctaveEngine
 
 from .dynamic import (
+    OctaveNamespaceProxy,
     OctavePtr,
     _make_function_ptr_instance,
+    _make_namespace_proxy,
     _make_user_class,
     _make_variable_ptr_instance,
 )
@@ -600,12 +602,17 @@ class Oct2Py:
         )
         self._engine.plot_settings = settings
 
-        dname = osp.dirname(func_path)
-        fname = osp.basename(func_path)
-        func_name, ext = osp.splitext(fname)
-        if ext and ext != ".m":
-            msg = "Need to give path to .m file"
-            raise TypeError(msg)
+        _is_dotted_name = kwargs.pop("_is_dotted_name", False)
+        if _is_dotted_name:
+            func_name = func_path
+            dname = ""
+        else:
+            dname = osp.dirname(func_path)
+            fname = osp.basename(func_path)
+            func_name, ext = osp.splitext(fname)
+            if ext and ext != ".m":
+                msg = "Need to give path to .m file"
+                raise TypeError(msg)
 
         if func_name == "clear":
             msg = 'Cannot use `clear` command directly, use eval("clear(var1, var2)")'
@@ -1122,10 +1129,7 @@ class Oct2Py:
         if exist == 0:
             cmd = "class(%s)" % name
             resp = self._engine.eval(cmd, silent=True).strip()
-            if "error:" in resp:
-                msg = 'Value "%s" does not exist in Octave workspace'
-                raise Oct2PyError(msg % name)
-            else:
+            if "error:" not in resp:
                 exist = 2
         return exist
 
@@ -1172,6 +1176,11 @@ class Oct2Py:
         exist = self._exist(name)
 
         if exist not in [2, 3, 5, 103]:
+            if exist in (0, 7):
+                # Name not found or is a directory — may be an Octave package
+                # namespace (+package). Return a lazy proxy; Octave will report
+                # an error at call time if the name is truly invalid.
+                return _make_namespace_proxy(self, name)
             msg = 'Name "%s" is not a valid callable, use `pull` for variables'
             raise Oct2PyError(msg % name)
 
@@ -1186,7 +1195,9 @@ class Oct2Py:
             obj = self._get_function_ptr(name)
 
         # !!! attr, *not* name, because we might have python keyword name!
-        setattr(self, attr, obj)
+        # Don't cache namespace proxies — the namespace isn't resolved yet.
+        if not isinstance(obj, OctaveNamespaceProxy):
+            setattr(self, attr, obj)
 
         return obj
 

--- a/oct2py/dynamic.py
+++ b/oct2py/dynamic.py
@@ -270,6 +270,41 @@ def _make_user_class(session, name, attrs=None):
     return type(str(name), (OctaveUserClass,), values)
 
 
+class OctaveNamespaceProxy:
+    """A lazy proxy for an Octave package namespace.
+
+    Returned when attribute access on an Oct2Py session resolves to a name
+    that doesn't exist as a plain function or variable in Octave — which
+    includes package-namespace prefixes like ``+package`` directories.
+
+    Chained access (``octave.pkg.sub.func``) keeps building the dotted
+    name; calling the proxy dispatches to ``feval``.
+    """
+
+    def __init__(self, session_weakref, prefix):
+        self._ref = session_weakref
+        self._prefix = prefix
+
+    def __getattr__(self, name):
+        """Return a child proxy, extending the dotted prefix."""
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return OctaveNamespaceProxy(self._ref, f"{self._prefix}.{name}")
+
+    def __call__(self, *inputs, **kwargs):
+        """Call the resolved dotted name as an Octave function."""
+        return self._ref().feval(self._prefix, *inputs, _is_dotted_name=True, **kwargs)
+
+    def __repr__(self):
+        """A string repr of the proxy."""
+        return f'Octave namespace proxy for "{self._prefix}"'
+
+
+def _make_namespace_proxy(session, prefix):
+    """Return a namespace proxy for an unresolved Octave name."""
+    return OctaveNamespaceProxy(weakref.ref(session), prefix)
+
+
 def _make_function_ptr_instance(session, name):
     ref = weakref.ref(session)
     doc = _DocDescriptor(ref, name)

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -85,7 +85,7 @@ class TestGetPointer:
 
     def test_get_pointer_undefined_raises(self):
         """Undefined name should raise Oct2PyError."""
-        with pytest.raises(Oct2PyError, match="does not exist"):
+        with pytest.raises(Oct2PyError, match="is undefined"):
             self.oc.get_pointer("_oct2py_no_such_var_xyz")
 
     def test_get_pointer_exist_zero_raises(self):
@@ -286,10 +286,10 @@ class TestExist:
         code = self.oc._exist("_test_exist_var")
         assert code == 1
 
-    def test_exist_zero_with_error_raises(self):
-        """_exist should raise for a truly undefined name."""
-        with pytest.raises(Oct2PyError, match="does not exist"):
-            self.oc._exist("_oct2py_no_such_xyz_999")
+    def test_exist_zero_with_error_returns_zero(self):
+        """_exist should return 0 for a truly undefined name."""
+        code = self.oc._exist("_oct2py_no_such_xyz_999")
+        assert code == 0
 
     def test_exist_zero_without_error_returns_two(self):
         """_exist should return 2 when exist==0 but class() succeeds."""
@@ -368,6 +368,49 @@ class TestGetattr:
         fn1 = self.oc.cos
         # After first access, the result should be cached on the instance
         assert self.oc.__dict__.get("cos") is fn1
+
+    def test_getattr_unknown_returns_namespace_proxy(self):
+        """__getattr__ on an unknown name should return a namespace proxy."""
+        from oct2py.dynamic import OctaveNamespaceProxy
+
+        proxy = self.oc.nonexistent_name_xyz
+        assert isinstance(proxy, OctaveNamespaceProxy)
+
+    def test_getattr_namespace_proxy_not_cached(self):
+        """Namespace proxies should not be cached on the session."""
+        from oct2py.dynamic import OctaveNamespaceProxy
+
+        proxy = self.oc.nonexistent_name_xyz
+        assert isinstance(proxy, OctaveNamespaceProxy)
+        assert "nonexistent_name_xyz" not in self.oc.__dict__
+
+    def test_getattr_package_namespace_chaining(self):
+        """Chained attribute access on a proxy should build the dotted prefix."""
+        from oct2py.dynamic import OctaveNamespaceProxy
+
+        proxy = self.oc.mypkg.myfunc
+        assert isinstance(proxy, OctaveNamespaceProxy)
+        assert proxy._prefix == "mypkg.myfunc"
+
+    def test_getattr_package_namespace_integration(self):
+        """Calling a function inside a +package directory should work."""
+        import textwrap
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_dir = os.path.join(tmpdir, "+testpkg286")
+            os.makedirs(pkg_dir)
+            m_file = os.path.join(pkg_dir, "add_one.m")
+            with open(m_file, "w") as f:
+                f.write(
+                    textwrap.dedent("""\
+                    function y = add_one(x)
+                      y = x + 1;
+                    end
+                """)
+                )
+            self.oc.addpath(tmpdir)
+            result = self.oc.testpkg286.add_one(3)
+            assert result == 4
 
 
 class TestGetMaxNout:

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -384,6 +384,14 @@ class TestGetattr:
         assert isinstance(proxy, OctaveNamespaceProxy)
         assert "nonexistent_name_xyz" not in self.oc.__dict__
 
+    def test_getattr_namespace_proxy_underscore_raises(self):
+        """Accessing a name starting with '_' on a proxy raises AttributeError."""
+        from oct2py.dynamic import OctaveNamespaceProxy
+
+        proxy = OctaveNamespaceProxy(None, "mypkg")
+        with pytest.raises(AttributeError):
+            _ = proxy._hidden
+
     def test_getattr_package_namespace_chaining(self):
         """Chained attribute access on a proxy should build the dotted prefix."""
         from oct2py.dynamic import OctaveNamespaceProxy

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -88,12 +88,11 @@ class TestUsage:
         tests = [self.oc.zeros, self.oc.ones, self.oc.plot]
         for item in tests:
             assert "class 'oct2py.dynamic" in repr(type(item))
-        with pytest.raises(Oct2PyError):
-            self.oc.__getattr__("aaldkfasd")
-        with pytest.raises(Oct2PyError):
-            self.oc.__getattr__("_foo")
-        with pytest.raises(Oct2PyError):
-            self.oc.__getattr__("foo\\W")
+        from oct2py.dynamic import OctaveNamespaceProxy
+
+        assert isinstance(self.oc.__getattr__("aaldkfasd"), OctaveNamespaceProxy)
+        assert isinstance(self.oc.__getattr__("_foo"), OctaveNamespaceProxy)
+        assert isinstance(self.oc.__getattr__("foo\\W"), OctaveNamespaceProxy)
 
     def test_open_close(self):
         """Test opening and closing the Octave session"""


### PR DESCRIPTION
## References

Closes #286

## Description

Octave functions inside `+package` directories are called using dot notation (`package.my_function(args)`). Previously, `Oct2Py.__getattr__` called `_exist(name)` and raised `Oct2PyError` immediately if the name wasn't found — but Octave's `exist('package')` returns 0 even for valid package names on the path, so all package access failed before Octave could resolve it.

## Changes

- **`oct2py/dynamic.py`**: Added `OctaveNamespaceProxy` class — a lazy proxy that builds dotted names on chained attribute access and dispatches to `feval` when called. Added `_make_namespace_proxy()` helper.
- **`oct2py/core.py`**:
  - `_exist()` now returns `0` for truly undefined names instead of raising, deferring the error to the caller.
  - `__getattr__` returns a namespace proxy when `exist in (0, 7)` instead of raising immediately.
  - Namespace proxies are not cached on the session instance.
  - `feval()` accepts an internal `_is_dotted_name` flag to bypass file-path parsing for dotted Octave names like `pkg.func`.
- **Tests**: Updated `test_core_branches.py` (4 new `TestGetattr` tests including a full integration test with a real `+package` directory) and `test_usage.py` to reflect that unknown names return proxies instead of raising immediately.

## Backwards-incompatible changes

`octave.typo` no longer raises immediately — it returns a proxy and Octave raises the error at call time. This is an intentional trade-off documented in the PR.

## Testing

- All 189 tests pass (`just test`)
- Type checking passes (`just typing`)
- Integration test creates a real `+testpkg286/add_one.m`, adds the directory to the Octave path, and verifies `octave.testpkg286.add_one(3) == 4`

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code