### PR TITLE
Add pydantic-settings support with Oct2PySettings and configure()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -39,3 +39,11 @@ jupyter:
 ## kill_octave
 
 ::: oct2py.kill_octave
+
+## Oct2PySettings
+
+::: oct2py.Oct2PySettings
+
+## configure
+
+::: oct2py.configure

--- a/docs/info.md
+++ b/docs/info.md
@@ -257,11 +257,38 @@ Traceback (most recent call last):
 oct2py.utils.Oct2PyError: Session timed out
 ```
 
+## Configuration & Settings
+
+All session defaults — timeout, executable, plot format, backend, and
+more — can be set in one place using `Oct2PySettings` and read from
+environment variables automatically.  See the
+[Configuration & Settings](settings.md) page for the full guide,
+including env var names, `.env` file support, and common recipes for
+headless, sandboxed, and CI environments.
+
+```python
+from oct2py import Oct2Py, Oct2PySettings
+
+s = Oct2PySettings(backend="disable", timeout=30, plot_format="png")
+oc = Oct2Py(settings=s)
+```
+
+Use `oct2py.configure()` to reconfigure the default global instance:
+
+```python
+import oct2py
+oct2py.configure(backend="disable", timeout=60)
+```
+
 ## Octave Executable
 
 By default, oct2py uses `octave` as the Octave executable. To use a
-different binary, set the `OCTAVE_EXECUTABLE` environment variable
-before starting Python:
+different binary, pass it directly or set the `OCTAVE_EXECUTABLE`
+environment variable:
+
+```python
+oc = Oct2Py(executable="/path/to/octave")
+```
 
 ```shell
 export OCTAVE_EXECUTABLE=/path/to/octave

--- a/docs/info.md
+++ b/docs/info.md
@@ -261,7 +261,7 @@ oct2py.utils.Oct2PyError: Session timed out
 
 All session defaults — timeout, executable, plot format, backend, and
 more — can be set in one place using `Oct2PySettings` and read from
-environment variables automatically.  See the
+environment variables automatically. See the
 [Configuration & Settings](settings.md) page for the full guide,
 including env var names, `.env` file support, and common recipes for
 headless, sandboxed, and CI environments.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,182 @@
+# Configuration & Settings
+
+`Oct2PySettings` provides a single object that carries all session defaults.
+It reads values from environment variables automatically, so you can configure
+oct2py without changing any code — useful in CI, Docker, or shared
+environments.
+
+## Quick start
+
+```python
+from oct2py import Oct2Py, Oct2PySettings
+
+s = Oct2PySettings(backend="disable", timeout=30, plot_format="png")
+oc = Oct2Py(settings=s)
+```
+
+Any field you do not set keeps its default value.  Individual keyword
+arguments to `Oct2Py` always take precedence over the settings object:
+
+```python
+# timeout from kwarg wins; everything else comes from settings
+oc = Oct2Py(settings=s, timeout=5)
+```
+
+## Environment variables
+
+Every field (except `executable`) is also readable from an environment
+variable prefixed with `OCT2PY_`.  This lets you configure a session
+without modifying source code:
+
+```shell
+export OCT2PY_BACKEND=disable
+export OCT2PY_TIMEOUT=60
+export OCT2PY_PLOT_FORMAT=png
+export OCT2PY_LOAD_OCTAVERC=false
+python myscript.py          # default `octave` instance picks these up
+```
+
+The default global `octave` instance is created at import time, so env
+vars must be set **before** `import oct2py`.
+
+### Octave executable aliases
+
+The `executable` field accepts two legacy environment variables in
+addition to `OCT2PY_EXECUTABLE`:
+
+| Variable | Priority |
+|---|---|
+| `OCTAVE_EXECUTABLE` | highest |
+| `OCTAVE` | fallback |
+
+```shell
+export OCTAVE_EXECUTABLE=/opt/octave-9/bin/octave-cli
+python myscript.py
+```
+
+## Reconfiguring the global instance
+
+Use `oct2py.configure()` to replace the global `octave` instance with
+one that uses new settings:
+
+```python
+import oct2py
+
+oct2py.configure(backend="disable", timeout=60)
+# oct2py.octave now uses those settings
+```
+
+You can also pass a pre-built `Oct2PySettings` object:
+
+```python
+from oct2py import Oct2PySettings
+import oct2py
+
+s = Oct2PySettings(backend="qt", plot_format="png", plot_width=1200)
+oct2py.configure(settings=s)
+```
+
+## Common recipes
+
+### Headless / CI environments
+
+Suppress all figure rendering so that Octave never tries to open a
+display:
+
+```python
+oc = Oct2Py(backend="disable")
+```
+
+Or via environment variable:
+
+```shell
+OCT2PY_BACKEND=disable python myscript.py
+```
+
+### Reproducible / sandboxed environments
+
+Skip loading `~/.octaverc` to prevent user configuration from affecting
+results:
+
+```python
+oc = Oct2Py(load_octaverc=False)
+```
+
+Or:
+
+```shell
+OCT2PY_LOAD_OCTAVERC=false python myscript.py
+```
+
+### Custom Octave executable
+
+```python
+oc = Oct2Py(executable="/opt/octave-9/bin/octave-cli")
+```
+
+After the session starts, `oc.executable` is updated to the full resolved
+path actually used.
+
+### Session-wide plot defaults
+
+Set default format, size, and resolution so you do not have to repeat
+them on every `eval` or `feval` call:
+
+```python
+oc = Oct2Py(plot_format="png", plot_width=1200, plot_height=900, plot_res=150)
+oc.eval("plot([1 2 3])", plot_dir="/tmp/figs")   # uses the instance defaults
+```
+
+Per-call arguments still override the instance defaults:
+
+```python
+oc.eval("plot([1 2 3])", plot_dir="/tmp/figs", plot_format="svg")  # svg this time
+```
+
+### Passing extra CLI options
+
+```python
+oc = Oct2Py(extra_cli_options="--traditional")
+```
+
+### Settings from a `.env` file
+
+`Oct2PySettings` is built on [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/),
+which supports `.env` files out of the box:
+
+```python
+from oct2py import Oct2PySettings
+
+s = Oct2PySettings(_env_file=".env")
+oc = Oct2Py(settings=s)
+```
+
+A `.env` file might look like:
+
+```ini
+OCT2PY_BACKEND=disable
+OCT2PY_TIMEOUT=120
+OCT2PY_PLOT_FORMAT=png
+```
+
+## Settings reference
+
+All fields and their defaults:
+
+| Field | Default | `OCT2PY_` env var | Description |
+|---|---|---|---|
+| `executable` | `None` | `OCT2PY_EXECUTABLE` (also `OCTAVE_EXECUTABLE`, `OCTAVE`) | Path to Octave binary |
+| `timeout` | `None` | `OCT2PY_TIMEOUT` | Command timeout in seconds |
+| `oned_as` | `"row"` | `OCT2PY_ONED_AS` | Write 1-D arrays as `"row"` or `"column"` vectors |
+| `temp_dir` | `None` | `OCT2PY_TEMP_DIR` | Directory for MAT exchange files |
+| `convert_to_float` | `True` | `OCT2PY_CONVERT_TO_FLOAT` | Convert integers to float before sending to Octave |
+| `backend` | `"default"` | `OCT2PY_BACKEND` | Graphics toolkit; `"disable"` suppresses all rendering |
+| `keep_matlab_shapes` | `False` | `OCT2PY_KEEP_MATLAB_SHAPES` | Preserve MATLAB array shapes (scalars as `(1,1)` etc.) |
+| `auto_show` | `None` | `OCT2PY_AUTO_SHOW` | Auto-display figures via matplotlib (default: on when `PYCHARM_HOSTED` is set) |
+| `load_octaverc` | `True` | `OCT2PY_LOAD_OCTAVERC` | Source `~/.octaverc` on startup |
+| `extra_cli_options` | `""` | `OCT2PY_EXTRA_CLI_OPTIONS` | Extra flags appended to the Octave invocation |
+| `plot_format` | `"svg"` | `OCT2PY_PLOT_FORMAT` | Default saved-plot format |
+| `plot_name` | `"plot"` | `OCT2PY_PLOT_NAME` | Default base name for saved plots |
+| `plot_width` | `None` | `OCT2PY_PLOT_WIDTH` | Default plot width in pixels |
+| `plot_height` | `None` | `OCT2PY_PLOT_HEIGHT` | Default plot height in pixels |
+| `plot_res` | `None` | `OCT2PY_PLOT_RES` | Default plot resolution in DPI |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -152,7 +152,8 @@ s = Oct2PySettings(_env_file=".env")
 oc = Oct2Py(settings=s)
 ```
 
-A `.env` file might look like:
+The path is resolved relative to the current working directory. A `.env` file
+might look like:
 
 ```ini
 OCT2PY_BACKEND=disable

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,9 +1,10 @@
 # Configuration & Settings
 
 `Oct2PySettings` provides a single object that carries all session defaults.
-It reads values from environment variables automatically, so you can configure
-oct2py without changing any code — useful in CI, Docker, or shared
-environments.
+It is built on [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/),
+which means it reads values from environment variables automatically, so you
+can configure oct2py without changing any code — useful in CI, Docker, or
+shared environments.
 
 ## Quick start
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -14,7 +14,7 @@ s = Oct2PySettings(backend="disable", timeout=30, plot_format="png")
 oc = Oct2Py(settings=s)
 ```
 
-Any field you do not set keeps its default value.  Individual keyword
+Any field you do not set keeps its default value. Individual keyword
 arguments to `Oct2Py` always take precedence over the settings object:
 
 ```python
@@ -25,7 +25,7 @@ oc = Oct2Py(settings=s, timeout=5)
 ## Environment variables
 
 Every field (except `executable`) is also readable from an environment
-variable prefixed with `OCT2PY_`.  This lets you configure a session
+variable prefixed with `OCT2PY_`. This lets you configure a session
 without modifying source code:
 
 ```shell

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ typing:
 
 # Build documentation
 docs:
-    uv run --group docs mkdocs build
+    uv run --group docs mkdocs build --strict
 
 # Serve documentation locally
 docs-serve:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,5 +42,6 @@ nav:
   - Examples: examples.md
   - Type Conversions: conversions.md
   - Example Notebook: notebook.ipynb
+  - Configuration: settings.md
   - API Reference: api.md
   - Information: info.md

--- a/oct2py/__init__.py
+++ b/oct2py/__init__.py
@@ -27,6 +27,7 @@ from ._version import __version__
 from .core import Oct2Py, OctaveWorkspaceProxy
 from .demo import demo
 from .io import Cell, Struct, StructArray
+from .settings import Oct2PySettings
 from .speed_check import speed_check
 from .thread_check import thread_check
 
@@ -34,10 +35,12 @@ __all__ = [
     "Cell",
     "Oct2Py",
     "Oct2PyError",
+    "Oct2PySettings",
     "OctaveWorkspaceProxy",
     "Struct",
     "StructArray",
     "__version__",
+    "configure",
     "demo",
     "get_log",
     "octave",
@@ -49,6 +52,30 @@ try:
     octave = Oct2Py()
 except Oct2PyError as e:
     print(e)  # noqa
+
+
+def configure(settings=None, **kwargs):
+    """Configure (or reconfigure) the default oct2py session.
+
+    Parameters
+    ----------
+    settings : Oct2PySettings, optional
+        Settings object. If not provided, one is built from kwargs and
+        any OCT2PY_* environment variables.
+    **kwargs
+        Passed directly to Oct2PySettings (e.g. ``backend="qt"``,
+        ``timeout=30``).
+
+    Examples
+    --------
+    >>> import oct2py
+    >>> oct2py.configure(backend="disable", timeout=30)  # doctest: +SKIP
+    """
+    global octave
+    if settings is None:
+        settings = Oct2PySettings(**kwargs)
+    octave.exit()
+    octave = Oct2Py(settings=settings)
 
 
 def kill_octave():

--- a/oct2py/__init__.py
+++ b/oct2py/__init__.py
@@ -71,7 +71,7 @@ def configure(settings=None, **kwargs):
     >>> import oct2py
     >>> oct2py.configure(backend="disable", timeout=30)  # doctest: +SKIP
     """
-    global octave
+    global octave  # noqa: PLW0603
     if settings is None:
         settings = Oct2PySettings(**kwargs)
     octave.exit()

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -207,37 +207,16 @@ class Oct2Py:
     ):
         if settings is None:
             settings = Oct2PySettings()
-        # Build a dict of explicitly-provided non-None kwargs and overlay onto settings.
-        _overrides = {
-            k: v
-            for k, v in dict(
-                timeout=timeout,
-                oned_as=oned_as,
-                temp_dir=temp_dir,
-                convert_to_float=convert_to_float,
-                backend=backend,
-                keep_matlab_shapes=keep_matlab_shapes,
-                auto_show=auto_show,
-                extra_cli_options=extra_cli_options,
-                executable=executable,
-                load_octaverc=load_octaverc,
-                plot_format=plot_format,
-                plot_name=plot_name,
-                plot_width=plot_width,
-                plot_height=plot_height,
-                plot_res=plot_res,
-            ).items()
-            if v is not None
-        }
-        if _overrides:
-            settings = settings.model_copy(update=_overrides)
         self._settings = settings
-        # Copy all standard settings fields to private instance attrs.
+        # For each settings field, use the kwarg if given, else fall back to settings.
+        _locals = locals()
         for _field in Oct2PySettings.model_fields:
-            if _field not in ("executable", "auto_show"):
-                setattr(self, f"_{_field}", getattr(settings, _field))
+            if _field in ("executable", "auto_show"):
+                continue
+            _kwarg = _locals.get(_field)
+            setattr(self, f"_{_field}", _kwarg if _kwarg is not None else getattr(settings, _field))
         # executable needs a non-None fallback.
-        self._executable = settings.executable or ""
+        self._executable = executable or settings.executable or ""
         self._engine = None
         self._logger = None
         self.logger = logger
@@ -245,7 +224,7 @@ class Oct2Py:
         self._user_classes = {}
         self._function_ptrs = {}
         # auto_show has additional env-var detection when not explicitly set.
-        _auto_show = settings.auto_show
+        _auto_show = auto_show if auto_show is not None else settings.auto_show
         if _auto_show is None:
             _auto_show = bool(os.environ.get("PYCHARM_HOSTED"))
             if self._backend == "disable":

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -153,19 +153,90 @@ class Oct2Py:
         and display them via matplotlib.  Defaults to True when the
         ``PYCHARM_HOSTED`` environment variable is set (i.e. when running
         inside PyCharm), False otherwise.  Set explicitly to override.
+    extra_cli_options : str, optional
+        Extra command-line options appended to the Octave invocation.
+    executable : str, optional
+        Path to the Octave executable. Resolved in order: this argument,
+        ``OCTAVE_EXECUTABLE`` env var, ``octave``/``octave-cli`` on
+        ``PATH``, then Flatpak.
+    load_octaverc : bool, optional
+        If True (default), source ``~/.octaverc`` during startup.  Set to
+        False to skip loading the user init file, which is useful in
+        reproducible or sandboxed environments where the init file may
+        alter the path, set conflicting options, or is simply unavailable.
+    plot_format : str, optional
+        Default format for saved plots (default ``"svg"``).
+    plot_name : str, optional
+        Default base name for saved plots (default ``"plot"``).
+    plot_width : int, optional
+        Default plot width in pixels.
+    plot_height : int, optional
+        Default plot height in pixels.
+    plot_res : int, optional
+        Default plot resolution in pixels per inch.
     """
 
     def __init__(  # noqa
         self,
+        settings=None,
         logger=None,
         timeout=None,
-        oned_as="row",
+        oned_as=None,
         temp_dir=None,
-        convert_to_float=True,
+        convert_to_float=None,
         backend=None,
-        keep_matlab_shapes=False,
+        keep_matlab_shapes=None,
         auto_show=None,
+        extra_cli_options=None,
+        executable=None,
+        load_octaverc=None,
+        plot_format=None,
+        plot_name=None,
+        plot_width=None,
+        plot_height=None,
+        plot_res=None,
     ):
+        from .settings import Oct2PySettings
+        if settings is None:
+            settings = Oct2PySettings()
+        # Apply settings as defaults for any unspecified kwargs
+        if oned_as is None:
+            oned_as = settings.oned_as
+        if convert_to_float is None:
+            convert_to_float = settings.convert_to_float
+        if backend is None:
+            backend = settings.backend
+        if keep_matlab_shapes is None:
+            keep_matlab_shapes = settings.keep_matlab_shapes
+        if timeout is None:
+            timeout = settings.timeout
+        if temp_dir is None:
+            temp_dir = settings.temp_dir
+        if extra_cli_options is None:
+            extra_cli_options = settings.extra_cli_options
+        if executable is None:
+            executable = settings.executable
+        if load_octaverc is None:
+            load_octaverc = settings.load_octaverc
+        if plot_format is None:
+            plot_format = settings.plot_format
+        if plot_name is None:
+            plot_name = settings.plot_name
+        if plot_width is None:
+            plot_width = settings.plot_width
+        if plot_height is None:
+            plot_height = settings.plot_height
+        if plot_res is None:
+            plot_res = settings.plot_res
+        self._settings = settings
+        self._extra_cli_options = extra_cli_options
+        self.executable = executable or ""
+        self._load_octaverc = load_octaverc
+        self.plot_format = plot_format
+        self.plot_name = plot_name
+        self.plot_width = plot_width
+        self.plot_height = plot_height
+        self.plot_res = plot_res
         self._oned_as = oned_as
         self._engine = None
         self._logger = None
@@ -178,6 +249,8 @@ class Oct2Py:
         self.convert_to_float = convert_to_float
         self._user_classes = {}
         self._function_ptrs = {}
+        if auto_show is None:
+            auto_show = settings.auto_show
         if auto_show is None:
             auto_show = bool(os.environ.get("PYCHARM_HOSTED"))
             if self.backend == "disable":
@@ -258,6 +331,7 @@ class Oct2Py:
         unless `convert_to_float=False`.
 
         """
+        timeout = timeout if timeout is not None else self.timeout
         if isinstance(name, str):
             name = [name]
             var = [var]
@@ -300,6 +374,7 @@ class Oct2Py:
           [u'spam', array([[1, 2, 3, 4]])]
 
         """
+        timeout = timeout if timeout is not None else self.timeout
         if isinstance(var, str):
             var = [var]
         outputs = []
@@ -379,6 +454,7 @@ class Oct2Py:
         -------
         A variable, object, user class, or function pointer as appropriate.
         """
+        timeout = timeout if timeout is not None else self.timeout
         if expr:
             tmp_name = f"_oct2py_expr_{uuid.uuid4().hex}"
             self.eval(f"{tmp_name} = {name}", timeout=timeout)
@@ -614,7 +690,8 @@ class Oct2Py:
         stream_handler = kwargs.get("stream_handler")
         verbose = kwargs.get("verbose", True)
         store_as = kwargs.get("store_as", "")
-        timeout = kwargs.get("timeout", self.timeout)
+        _t = kwargs.get("timeout")
+        timeout = _t if _t is not None else self.timeout
         if not stream_handler:
             stream_handler = self.logger.info if verbose else self.logger.debug
 
@@ -637,8 +714,8 @@ class Oct2Py:
         stream_handler=None,
         temp_dir=None,
         plot_dir=None,
-        plot_name="plot",
-        plot_format="svg",
+        plot_name=None,
+        plot_format=None,
         plot_backend=None,
         plot_width=None,
         plot_height=None,
@@ -735,6 +812,13 @@ class Oct2Py:
         """  # noqa: DOC103
         if isinstance(cmds, str):
             cmds = [cmds]
+
+        timeout = timeout if timeout is not None else self.timeout
+        plot_name = plot_name if plot_name is not None else self.plot_name
+        plot_format = plot_format if plot_format is not None else self.plot_format
+        plot_width = plot_width if plot_width is not None else self.plot_width
+        plot_height = plot_height if plot_height is not None else self.plot_height
+        plot_res = plot_res if plot_res is not None else self.plot_res
 
         prev_temp_dir = self.temp_dir
         self.temp_dir = temp_dir or self.temp_dir
@@ -842,10 +926,8 @@ class Oct2Py:
         if self._engine:
             self._engine.repl.terminate()
 
-        # OctaveEngine resolves OCTAVE_EXECUTABLE from its env; honour the
-        # legacy OCTAVE alias by passing it explicitly when OCTAVE_EXECUTABLE
-        # is absent.
-        _executable = os.environ.get("OCTAVE_EXECUTABLE") or os.environ.get("OCTAVE", "")
+        # Use the stored executable (may be empty, letting OctaveEngine resolve).
+        _executable = self.executable
 
         # Preserve the SIGINT handler across engine startup.  The underlying
         # pexpect spawn temporarily replaces SIGINT with SIG_DFL so that the
@@ -863,12 +945,6 @@ class Oct2Py:
 
         _qt_plugin_path = None
         try:
-            # Pass --no-line-editing to avoid readline overhead on every function
-            # call in Octave 7+. In interactive mode, readline does expensive
-            # terminal processing after each function call (~0.5s on some
-            # systems), which is unnecessary since oct2py drives Octave
-            # programmatically via pexpect.
-            #
             # Use a weakref-based wrapper so that OctaveEngine (and its atexit
             # registration) does not hold a strong reference back to this Oct2Py
             # instance, which would otherwise prevent __del__ / exit() from ever
@@ -892,7 +968,8 @@ class Oct2Py:
                 executable=_executable,
                 stdin_handler=_stdin_handler,
                 logger=self.logger,
-                cli_options="--no-line-editing",
+                cli_options=self._extra_cli_options,
+                load_octaverc=self._load_octaverc,
             )
         except Exception as e:
             raise Oct2PyError(str(e)) from None
@@ -903,7 +980,8 @@ class Oct2Py:
             if _qt_plugin_path is not None:
                 os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = _qt_plugin_path
 
-        _augment_path_for_windows(self._engine.executable)
+        self.executable = self._engine.executable
+        _augment_path_for_windows(self.executable)
 
         # Set up the temp directory for MAT file exchange.
         if self.temp_dir is None:

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -27,6 +27,7 @@ from .dynamic import (
     _make_variable_ptr_instance,
 )
 from .io import Cell, StructArray, read_file, write_file
+from .settings import Oct2PySettings
 from .utils import Oct2PyError, _augment_path_for_windows, get_log
 
 HERE = osp.realpath(osp.dirname(__file__))
@@ -126,6 +127,11 @@ class Oct2Py:
 
     Parameters
     ----------
+    settings : Oct2PySettings, optional
+        Settings object supplying defaults for all other parameters.
+        When omitted, a default ``Oct2PySettings()`` is created (which
+        reads ``OCT2PY_*`` environment variables automatically).
+        Explicit keyword arguments always override values from settings.
     logger : logging object, optional
         Optional logger to use for Oct2Py session
     timeout : float, optional
@@ -196,7 +202,6 @@ class Oct2Py:
         plot_height=None,
         plot_res=None,
     ):
-        from .settings import Oct2PySettings
         if settings is None:
             settings = Oct2PySettings()
         # Apply settings as defaults for any unspecified kwargs

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -34,6 +34,7 @@ from .utils import Oct2PyError, _augment_path_for_windows, get_log
 
 HERE = osp.realpath(osp.dirname(__file__))
 
+
 # Registry of all live Oct2Py instances, held via weak references so they can
 # be garbage-collected normally.  Used by the post-fork handler below.
 _instances: weakref.WeakSet["Oct2Py"] = weakref.WeakSet()
@@ -206,63 +207,50 @@ class Oct2Py:
     ):
         if settings is None:
             settings = Oct2PySettings()
-        # Apply settings as defaults for any unspecified kwargs
-        if oned_as is None:
-            oned_as = settings.oned_as
-        if convert_to_float is None:
-            convert_to_float = settings.convert_to_float
-        if backend is None:
-            backend = settings.backend
-        if keep_matlab_shapes is None:
-            keep_matlab_shapes = settings.keep_matlab_shapes
-        if timeout is None:
-            timeout = settings.timeout
-        if temp_dir is None:
-            temp_dir = settings.temp_dir
-        if extra_cli_options is None:
-            extra_cli_options = settings.extra_cli_options
-        if executable is None:
-            executable = settings.executable
-        if load_octaverc is None:
-            load_octaverc = settings.load_octaverc
-        if plot_format is None:
-            plot_format = settings.plot_format
-        if plot_name is None:
-            plot_name = settings.plot_name
-        if plot_width is None:
-            plot_width = settings.plot_width
-        if plot_height is None:
-            plot_height = settings.plot_height
-        if plot_res is None:
-            plot_res = settings.plot_res
+        # Build a dict of explicitly-provided non-None kwargs and overlay onto settings.
+        _overrides = {
+            k: v
+            for k, v in dict(
+                timeout=timeout,
+                oned_as=oned_as,
+                temp_dir=temp_dir,
+                convert_to_float=convert_to_float,
+                backend=backend,
+                keep_matlab_shapes=keep_matlab_shapes,
+                auto_show=auto_show,
+                extra_cli_options=extra_cli_options,
+                executable=executable,
+                load_octaverc=load_octaverc,
+                plot_format=plot_format,
+                plot_name=plot_name,
+                plot_width=plot_width,
+                plot_height=plot_height,
+                plot_res=plot_res,
+            ).items()
+            if v is not None
+        }
+        if _overrides:
+            settings = settings.model_copy(update=_overrides)
         self._settings = settings
-        self._extra_cli_options = extra_cli_options
-        self.executable = executable or ""
-        self._load_octaverc = load_octaverc
-        self.plot_format = plot_format
-        self.plot_name = plot_name
-        self.plot_width = plot_width
-        self.plot_height = plot_height
-        self.plot_res = plot_res
-        self._oned_as = oned_as
+        # Copy all standard settings fields to private instance attrs.
+        for _field in Oct2PySettings.model_fields:
+            if _field not in ("executable", "auto_show"):
+                setattr(self, f"_{_field}", getattr(settings, _field))
+        # executable needs a non-None fallback.
+        self._executable = settings.executable or ""
         self._engine = None
         self._logger = None
         self.logger = logger
-        self.timeout = timeout
-        self.backend = backend if backend is not None else "default"
-        self.keep_matlab_shapes = keep_matlab_shapes
-        self.temp_dir = temp_dir
         self._temp_dir_owner = False
-        self.convert_to_float = convert_to_float
         self._user_classes = {}
         self._function_ptrs = {}
-        if auto_show is None:
-            auto_show = settings.auto_show
-        if auto_show is None:
-            auto_show = bool(os.environ.get("PYCHARM_HOSTED"))
-            if self.backend == "disable":
-                auto_show = False
-        self._auto_show = auto_show
+        # auto_show has additional env-var detection when not explicitly set.
+        _auto_show = settings.auto_show
+        if _auto_show is None:
+            _auto_show = bool(os.environ.get("PYCHARM_HOSTED"))
+            if self._backend == "disable":
+                _auto_show = False
+        self._auto_show = _auto_show
         _instances.add(self)
         self.restart()
 
@@ -276,6 +264,105 @@ class Oct2Py:
         self._logger = value or get_log()
         if self._engine:
             self._engine.logger = self._logger
+
+    @property
+    def timeout(self):
+        """Timeout in seconds for Octave commands."""
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        self._timeout = value
+
+    @property
+    def backend(self):
+        """Graphics toolkit used for plotting."""
+        return self._backend
+
+    @backend.setter
+    def backend(self, value):
+        self._backend = value
+
+    @property
+    def executable(self):
+        """Path to the Octave executable."""
+        return self._executable
+
+    @executable.setter
+    def executable(self, value):
+        self._executable = value
+
+    @property
+    def temp_dir(self):
+        """Directory used for MAT exchange files."""
+        return self._temp_dir
+
+    @temp_dir.setter
+    def temp_dir(self, value):
+        self._temp_dir = value
+
+    @property
+    def convert_to_float(self):
+        """If True, convert integer types to float before sending to Octave."""
+        return self._convert_to_float
+
+    @convert_to_float.setter
+    def convert_to_float(self, value):
+        self._convert_to_float = value
+
+    @property
+    def keep_matlab_shapes(self):
+        """If True, preserve MATLAB array shapes."""
+        return self._keep_matlab_shapes
+
+    @keep_matlab_shapes.setter
+    def keep_matlab_shapes(self, value):
+        self._keep_matlab_shapes = value
+
+    @property
+    def plot_format(self):
+        """Default format for saved plots."""
+        return self._plot_format
+
+    @plot_format.setter
+    def plot_format(self, value):
+        self._plot_format = value
+
+    @property
+    def plot_name(self):
+        """Default base name for saved plots."""
+        return self._plot_name
+
+    @plot_name.setter
+    def plot_name(self, value):
+        self._plot_name = value
+
+    @property
+    def plot_width(self):
+        """Default plot width in pixels."""
+        return self._plot_width
+
+    @plot_width.setter
+    def plot_width(self, value):
+        self._plot_width = value
+
+    @property
+    def plot_height(self):
+        """Default plot height in pixels."""
+        return self._plot_height
+
+    @plot_height.setter
+    def plot_height(self, value):
+        self._plot_height = value
+
+    @property
+    def plot_res(self):
+        """Default plot resolution in pixels per inch."""
+        return self._plot_res
+
+    @plot_res.setter
+    def plot_res(self, value):
+        self._plot_res = value
 
     def __enter__(self):
         """Return octave object, restart session if necessary"""

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -1034,7 +1034,12 @@ class Oct2Py:
             ref_indices=ref_arr,
         )
 
-        write_file(req, out_file, oned_as=self._settings.oned_as, convert_to_float=self._settings.convert_to_float)
+        write_file(
+            req,
+            out_file,
+            oned_as=self._settings.oned_as,
+            convert_to_float=self._settings.convert_to_float,
+        )
 
         # Set up the engine and evaluate the `_pyeval()` function.
         engine.line_handler = stream_handler or self.logger.info

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -63,7 +63,7 @@ def _reset_instances_after_fork() -> None:
         # Prevent exit() / __del__ from touching the parent's engine.
         inst._engine = None
         inst._temp_dir_owner = False
-        inst.temp_dir = None
+        inst._settings.temp_dir = None
     # The parent's atexit.register(shutil.rmtree, temp_dir, ...) calls are
     # inherited by the child.  Remove them so the child doesn't delete the
     # parent's /dev/shm temp directories on exit.  Any new Oct2Py instances
@@ -207,29 +207,26 @@ class Oct2Py:
     ):
         if settings is None:
             settings = Oct2PySettings()
-        self._settings = settings
-        # For each settings field, use the kwarg if given, else fall back to settings.
+        # Apply any explicit kwargs as overrides on top of the settings object.
         _locals = locals()
-        for _field in Oct2PySettings.model_fields:
-            if _field in ("executable", "auto_show"):
-                continue
-            _kwarg = _locals.get(_field)
-            setattr(self, f"_{_field}", _kwarg if _kwarg is not None else getattr(settings, _field))
-        # executable needs a non-None fallback.
-        self._executable = executable or settings.executable or ""
+        _overrides = {
+            f: _locals[f]
+            for f in Oct2PySettings.model_fields
+            if f != "auto_show" and _locals.get(f) is not None
+        }
+        # Resolve auto_show: explicit kwarg > settings > env detection.
+        _auto_show = auto_show if auto_show is not None else settings.auto_show
+        if _auto_show is None:
+            _auto_show = bool(os.environ.get("PYCHARM_HOSTED"))
+            if _overrides.get("backend", settings.backend) == "disable":
+                _auto_show = False
+        self._settings = settings.model_copy(update={**_overrides, "auto_show": _auto_show})
         self._engine = None
         self._logger = None
         self.logger = logger
         self._temp_dir_owner = False
         self._user_classes = {}
         self._function_ptrs = {}
-        # auto_show has additional env-var detection when not explicitly set.
-        _auto_show = auto_show if auto_show is not None else settings.auto_show
-        if _auto_show is None:
-            _auto_show = bool(os.environ.get("PYCHARM_HOSTED"))
-            if self._backend == "disable":
-                _auto_show = False
-        self._auto_show = _auto_show
         _instances.add(self)
         self.restart()
 
@@ -245,103 +242,13 @@ class Oct2Py:
             self._engine.logger = self._logger
 
     @property
-    def timeout(self):
-        """Timeout in seconds for Octave commands."""
-        return self._timeout
+    def settings(self):
+        """The session's current settings."""
+        return self._settings
 
-    @timeout.setter
-    def timeout(self, value):
-        self._timeout = value
-
-    @property
-    def backend(self):
-        """Graphics toolkit used for plotting."""
-        return self._backend
-
-    @backend.setter
-    def backend(self, value):
-        self._backend = value
-
-    @property
-    def executable(self):
-        """Path to the Octave executable."""
-        return self._executable
-
-    @executable.setter
-    def executable(self, value):
-        self._executable = value
-
-    @property
-    def temp_dir(self):
-        """Directory used for MAT exchange files."""
-        return self._temp_dir
-
-    @temp_dir.setter
-    def temp_dir(self, value):
-        self._temp_dir = value
-
-    @property
-    def convert_to_float(self):
-        """If True, convert integer types to float before sending to Octave."""
-        return self._convert_to_float
-
-    @convert_to_float.setter
-    def convert_to_float(self, value):
-        self._convert_to_float = value
-
-    @property
-    def keep_matlab_shapes(self):
-        """If True, preserve MATLAB array shapes."""
-        return self._keep_matlab_shapes
-
-    @keep_matlab_shapes.setter
-    def keep_matlab_shapes(self, value):
-        self._keep_matlab_shapes = value
-
-    @property
-    def plot_format(self):
-        """Default format for saved plots."""
-        return self._plot_format
-
-    @plot_format.setter
-    def plot_format(self, value):
-        self._plot_format = value
-
-    @property
-    def plot_name(self):
-        """Default base name for saved plots."""
-        return self._plot_name
-
-    @plot_name.setter
-    def plot_name(self, value):
-        self._plot_name = value
-
-    @property
-    def plot_width(self):
-        """Default plot width in pixels."""
-        return self._plot_width
-
-    @plot_width.setter
-    def plot_width(self, value):
-        self._plot_width = value
-
-    @property
-    def plot_height(self):
-        """Default plot height in pixels."""
-        return self._plot_height
-
-    @plot_height.setter
-    def plot_height(self, value):
-        self._plot_height = value
-
-    @property
-    def plot_res(self):
-        """Default plot resolution in pixels per inch."""
-        return self._plot_res
-
-    @plot_res.setter
-    def plot_res(self, value):
-        self._plot_res = value
+    @settings.setter
+    def settings(self, value):
+        self._settings = value
 
     def __enter__(self):
         """Return octave object, restart session if necessary"""
@@ -367,9 +274,9 @@ class Oct2Py:
                 atexit.unregister(self._engine._cleanup)
             self._engine.repl.terminate()
         self._engine = None
-        if self._temp_dir_owner and self.temp_dir and osp.isdir(self.temp_dir):
-            shutil.rmtree(self.temp_dir, ignore_errors=True)
-            self.temp_dir = None
+        if self._temp_dir_owner and self._settings.temp_dir and osp.isdir(self._settings.temp_dir):
+            shutil.rmtree(self._settings.temp_dir, ignore_errors=True)
+            self._settings.temp_dir = None
             self._temp_dir_owner = False
 
     def push(self, name, var, timeout=None, verbose=True):
@@ -404,7 +311,7 @@ class Oct2Py:
         unless `convert_to_float=False`.
 
         """
-        timeout = timeout if timeout is not None else self.timeout
+        timeout = timeout if timeout is not None else self._settings.timeout
         if isinstance(name, str):
             name = [name]
             var = [var]
@@ -447,7 +354,7 @@ class Oct2Py:
           [u'spam', array([[1, 2, 3, 4]])]
 
         """
-        timeout = timeout if timeout is not None else self.timeout
+        timeout = timeout if timeout is not None else self._settings.timeout
         if isinstance(var, str):
             var = [var]
         outputs = []
@@ -527,7 +434,7 @@ class Oct2Py:
         -------
         A variable, object, user class, or function pointer as appropriate.
         """
-        timeout = timeout if timeout is not None else self.timeout
+        timeout = timeout if timeout is not None else self._settings.timeout
         if expr:
             tmp_name = f"_oct2py_expr_{uuid.uuid4().hex}"
             self.eval(f"{tmp_name} = {name}", timeout=timeout)
@@ -597,7 +504,7 @@ class Oct2Py:
         """Capture open Octave figures and display them via matplotlib."""
         if not self._engine:
             return
-        if self.backend == "disable":
+        if self._settings.backend == "disable":
             return
         try:
             import matplotlib.image as mpimg  # noqa: PLC0415
@@ -605,7 +512,7 @@ class Oct2Py:
         except ImportError:  # pragma: no cover
             return
 
-        plot_dir = tempfile.mkdtemp(dir=self.temp_dir)
+        plot_dir = tempfile.mkdtemp(dir=self._settings.temp_dir)
         try:
             # Temporarily switch to inline mode so _make_figures uses a
             # headless-compatible toolkit (gnuplot/qt offscreen) rather than
@@ -733,7 +640,7 @@ class Oct2Py:
         plot_dir = kwargs.get("plot_dir")
 
         # Choose appropriate plot backend.
-        default_backend = "inline" if plot_dir else self.backend
+        default_backend = "inline" if plot_dir else self._settings.backend
         backend = kwargs.get("plot_backend", default_backend)
         # Map "disable" to "inline" so octave_kernel sets defaultfigurevisible=off.
         if backend == "disable":
@@ -769,7 +676,7 @@ class Oct2Py:
         verbose = kwargs.get("verbose", True)
         store_as = kwargs.get("store_as", "")
         _t = kwargs.get("timeout")
-        timeout = _t if _t is not None else self.timeout
+        timeout = _t if _t is not None else self._settings.timeout
         if not stream_handler:
             stream_handler = self.logger.info if verbose else self.logger.debug
 
@@ -891,15 +798,15 @@ class Oct2Py:
         if isinstance(cmds, str):
             cmds = [cmds]
 
-        timeout = timeout if timeout is not None else self.timeout
-        plot_name = plot_name if plot_name is not None else self.plot_name
-        plot_format = plot_format if plot_format is not None else self.plot_format
-        plot_width = plot_width if plot_width is not None else self.plot_width
-        plot_height = plot_height if plot_height is not None else self.plot_height
-        plot_res = plot_res if plot_res is not None else self.plot_res
+        timeout = timeout if timeout is not None else self._settings.timeout
+        plot_name = plot_name if plot_name is not None else self._settings.plot_name
+        plot_format = plot_format if plot_format is not None else self._settings.plot_format
+        plot_width = plot_width if plot_width is not None else self._settings.plot_width
+        plot_height = plot_height if plot_height is not None else self._settings.plot_height
+        plot_res = plot_res if plot_res is not None else self._settings.plot_res
 
-        prev_temp_dir = self.temp_dir
-        self.temp_dir = temp_dir or self.temp_dir
+        prev_temp_dir = self._settings.temp_dir
+        self._settings.temp_dir = temp_dir or self._settings.temp_dir
         prev_log_level = self.logger.level
 
         if kwargs.get("log") is False:
@@ -938,7 +845,7 @@ class Oct2Py:
             if resp is not None:
                 ans = resp
 
-        self.temp_dir = prev_temp_dir
+        self._settings.temp_dir = prev_temp_dir
         self.logger.setLevel(prev_log_level)
 
         if return_both:
@@ -1005,7 +912,7 @@ class Oct2Py:
             self._engine.repl.terminate()
 
         # Use the stored executable (may be empty, letting OctaveEngine resolve).
-        _executable = self.executable
+        _executable = self._settings.executable or ""
 
         # Preserve the SIGINT handler across engine startup.  The underlying
         # pexpect spawn temporarily replaces SIGINT with SIG_DFL so that the
@@ -1046,8 +953,8 @@ class Oct2Py:
                 executable=_executable,
                 stdin_handler=_stdin_handler,
                 logger=self.logger,
-                cli_options=self._extra_cli_options,
-                load_octaverc=self._load_octaverc,
+                cli_options=self._settings.extra_cli_options,
+                load_octaverc=self._settings.load_octaverc,
             )
         except Exception as e:
             raise Oct2PyError(str(e)) from None
@@ -1058,11 +965,11 @@ class Oct2Py:
             if _qt_plugin_path is not None:
                 os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = _qt_plugin_path
 
-        self.executable = self._engine.executable
-        _augment_path_for_windows(self.executable)
+        self._settings.executable = self._engine.executable
+        _augment_path_for_windows(self._settings.executable)
 
         # Set up the temp directory for MAT file exchange.
-        if self.temp_dir is None:
+        if self._settings.temp_dir is None:
             # Prefer a RAM-based filesystem (tmpfs) for faster file I/O.
             # On Linux, /dev/shm is always in RAM and avoids disk latency,
             # which is critical for performance in Octave 7+ where save/load
@@ -1071,11 +978,11 @@ class Oct2Py:
             sandboxed = "snap" in executable or "flatpak" in executable
             shm = "/dev/shm"  # noqa: S108
             if not sandboxed and osp.isdir(shm) and os.access(shm, os.W_OK):
-                self.temp_dir = tempfile.mkdtemp(dir=shm, prefix="oct2py_")
-                atexit.register(shutil.rmtree, self.temp_dir, True)
+                self._settings.temp_dir = tempfile.mkdtemp(dir=shm, prefix="oct2py_")
+                atexit.register(shutil.rmtree, self._settings.temp_dir, True)
             else:
-                self.temp_dir = os.path.join(self._engine.tmp_dir, "oct2py")
-                os.makedirs(self.temp_dir, exist_ok=True)
+                self._settings.temp_dir = os.path.join(self._engine.tmp_dir, "oct2py")
+                os.makedirs(self._settings.temp_dir, exist_ok=True)
             self._temp_dir_owner = True
 
         # Add local Octave scripts.
@@ -1104,9 +1011,9 @@ class Oct2Py:
             raise Oct2PyError(msg)
 
         # Set up our mat file paths.
-        out_file = osp.join(self.temp_dir, "writer.mat")
+        out_file = osp.join(self._settings.temp_dir, "writer.mat")
         out_file = out_file.replace(osp.sep, "/")
-        in_file = osp.join(self.temp_dir, "reader.mat")
+        in_file = osp.join(self._settings.temp_dir, "reader.mat")
         in_file = in_file.replace(osp.sep, "/")
 
         func_args = list(func_args)
@@ -1127,12 +1034,12 @@ class Oct2Py:
             ref_indices=ref_arr,
         )
 
-        write_file(req, out_file, oned_as=self._oned_as, convert_to_float=self.convert_to_float)
+        write_file(req, out_file, oned_as=self._settings.oned_as, convert_to_float=self._settings.convert_to_float)
 
         # Set up the engine and evaluate the `_pyeval()` function.
         engine.line_handler = stream_handler or self.logger.info
         if timeout is None:
-            timeout = self.timeout
+            timeout = self._settings.timeout
 
         try:
             engine.eval(f'_pyeval("{out_file}", "{in_file}");', timeout=timeout)
@@ -1172,7 +1079,7 @@ class Oct2Py:
 
         if plot_dir:
             engine.make_figures(plot_dir)
-        elif self._auto_show:
+        elif self._settings.auto_show:
             self._show_figures()
 
         return result

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -35,7 +35,7 @@ _WRITE_LOCK = threading.Lock()
 def read_file(path, session=None, keep_matlab_shapes=False):
     """Read the data from the given file path."""
     if session:
-        keep_matlab_shapes = keep_matlab_shapes or session.keep_matlab_shapes
+        keep_matlab_shapes = keep_matlab_shapes or session.settings.keep_matlab_shapes
     try:
         data = loadmat(path, struct_as_record=True)
     except UnicodeDecodeError as e:

--- a/oct2py/ipython/octavemagic.py
+++ b/oct2py/ipython/octavemagic.py
@@ -265,7 +265,7 @@ class OctaveMagics(Magics):
         temp_dir = args.temp_dir
         if temp_dir and not os.path.isdir(temp_dir):
             temp_dir = None
-        temp_dir = temp_dir or self._oct.temp_dir
+        temp_dir = temp_dir or self._oct.settings.temp_dir
 
         # Put the plots in the temp directory so we don't have to make another
         # temporary directory.

--- a/oct2py/settings.py
+++ b/oct2py/settings.py
@@ -1,0 +1,91 @@
+"""Settings for oct2py sessions."""
+# Copyright (c) oct2py developers.
+# Distributed under the terms of the MIT License.
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Oct2PySettings(BaseSettings):
+    """Settings for an Oct2Py session.
+
+    Can be populated from environment variables (prefixed with ``OCT2PY_``),
+    a ``.env`` file, or programmatically.
+
+    Attributes
+    ----------
+    executable : str, optional
+        Path to the Octave executable. Resolved in order: this argument,
+        ``OCTAVE_EXECUTABLE`` env var, ``octave``/``octave-cli`` on
+        ``PATH``, then Flatpak.
+    timeout : float, optional
+        Timeout in seconds for Octave commands.
+    oned_as : str
+        If ``"column"``, write 1-D numpy arrays as column vectors.
+        If ``"row"`` (default), write 1-D numpy arrays as row vectors.
+    temp_dir : str, optional
+        Directory for MAT files.
+    convert_to_float : bool
+        If True (default), convert integer types to float when passing to Octave.
+    backend : str
+        The graphics_toolkit to use for plotting. Use ``"disable"`` to suppress
+        all figure rendering.
+    keep_matlab_shapes : bool
+        If True, preserve MATLAB shapes (e.g. scalars as (1,1)).
+    auto_show : bool, optional
+        If True, automatically display figures after each call.
+    plot_format : str
+        Default format for saved plots (default ``"svg"``).
+    plot_name : str
+        Default base name for saved plots (default ``"plot"``).
+    plot_width : int, optional
+        Default plot width in pixels.
+    plot_height : int, optional
+        Default plot height in pixels.
+    plot_res : int, optional
+        Default plot resolution in pixels per inch.
+    extra_cli_options : str
+        Extra command-line options appended to the Octave invocation.
+    load_octaverc : bool
+        If True (default), source ``~/.octaverc`` during startup.  Set to
+        False to skip loading the user init file, which is useful in
+        reproducible or sandboxed environments where the init file may
+        alter the path, set conflicting options, or is simply unavailable.
+
+    Examples
+    --------
+    >>> s = Oct2PySettings(backend="disable", timeout=30)
+    >>> s.backend
+    'disable'
+    >>> s.timeout
+    30.0
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="OCT2PY_",
+        populate_by_name=True,
+    )
+
+    # Octave executable — reads OCTAVE_EXECUTABLE or OCTAVE env vars
+    executable: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OCTAVE_EXECUTABLE", "OCTAVE"),
+    )
+
+    # Session settings
+    timeout: float | None = None
+    oned_as: str = "row"
+    temp_dir: str | None = None
+    convert_to_float: bool = True
+    backend: str = "default"
+    keep_matlab_shapes: bool = False
+    auto_show: bool | None = None
+
+    # Plot defaults
+    plot_format: str = "svg"
+    plot_name: str = "plot"
+    plot_width: int | None = None
+    plot_height: int | None = None
+    plot_res: int | None = None
+    extra_cli_options: str = ""
+    load_octaverc: bool = True

--- a/oct2py/settings.py
+++ b/oct2py/settings.py
@@ -14,6 +14,9 @@ class Oct2PySettings(BaseSettings):
 
     Attributes
     ----------
+    model_config : SettingsConfigDict
+        Pydantic-settings configuration: ``env_prefix="OCT2PY_"``,
+        ``populate_by_name=True``.
     executable : str, optional
         Path to the Octave executable. Resolved in order: this argument,
         ``OCTAVE_EXECUTABLE`` env var, ``octave``/``octave-cli`` on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy >=1.24",
     "scipy >=1.9.0",
-    "octave_kernel >= 0.39",
+    "octave-kernel>=1.0.0rc0",
+    "pydantic-settings>=2.0",
 ]
 readme = "README.md"
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -155,7 +155,7 @@ class TestConversions:
                 pass
             else:
                 assert octave_type == oct_type or (
-                    octave_type == "double" and self.oc.convert_to_float
+                    octave_type == "double" and self.oc.settings.convert_to_float
                 )
             if out_type is None:
                 assert np.isnan(incoming)

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -33,11 +33,11 @@ class TestInit:
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py(settings=s)
-        assert oc.backend == "disable"
-        assert oc.timeout == 42
-        assert oc._oned_as == "column"
-        assert oc.convert_to_float is False
-        assert oc.keep_matlab_shapes is True
+        assert oc.settings.backend == "disable"
+        assert oc.settings.timeout == 42
+        assert oc.settings.oned_as == "column"
+        assert oc.settings.convert_to_float is False
+        assert oc.settings.keep_matlab_shapes is True
         oc._engine = None
 
     def test_kwargs_override_settings(self):
@@ -46,8 +46,8 @@ class TestInit:
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py(settings=s, backend="default", timeout=7)
-        assert oc.backend == "default"
-        assert oc.timeout == 7
+        assert oc.settings.backend == "default"
+        assert oc.settings.timeout == 7
         oc._engine = None
 
     def test_default_settings_created_when_none(self):
@@ -55,7 +55,7 @@ class TestInit:
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py()
-        assert isinstance(oc._settings, Oct2PySettings)
+        assert isinstance(oc.settings, Oct2PySettings)
         oc._engine = None
 
     # --- extra_cli_options parameter ---
@@ -112,7 +112,7 @@ class TestInit:
         fake = self._make_fake_engine(executable="/resolved/octave-cli")
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py(executable="/custom/octave")
-        assert oc.executable == "/resolved/octave-cli"
+        assert oc.settings.executable == "/resolved/octave-cli"
         oc._engine = None
 
     def test_executable_from_settings(self):
@@ -176,11 +176,11 @@ class TestInit:
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py()
-        assert oc.plot_format == "svg"
-        assert oc.plot_name == "plot"
-        assert oc.plot_width is None
-        assert oc.plot_height is None
-        assert oc.plot_res is None
+        assert oc.settings.plot_format == "svg"
+        assert oc.settings.plot_name == "plot"
+        assert oc.settings.plot_width is None
+        assert oc.settings.plot_height is None
+        assert oc.settings.plot_res is None
         oc._engine = None
 
     def test_plot_params_from_kwargs(self):
@@ -190,11 +190,11 @@ class TestInit:
             oc = Oct2Py(
                 plot_format="png", plot_name="fig", plot_width=800, plot_height=600, plot_res=150
             )
-        assert oc.plot_format == "png"
-        assert oc.plot_name == "fig"
-        assert oc.plot_width == 800
-        assert oc.plot_height == 600
-        assert oc.plot_res == 150
+        assert oc.settings.plot_format == "png"
+        assert oc.settings.plot_name == "fig"
+        assert oc.settings.plot_width == 800
+        assert oc.settings.plot_height == 600
+        assert oc.settings.plot_res == 150
         oc._engine = None
 
     def test_plot_params_from_settings(self):
@@ -205,11 +205,11 @@ class TestInit:
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py(settings=s)
-        assert oc.plot_format == "png"
-        assert oc.plot_name == "fig"
-        assert oc.plot_width == 800
-        assert oc.plot_height == 600
-        assert oc.plot_res == 150
+        assert oc.settings.plot_format == "png"
+        assert oc.settings.plot_name == "fig"
+        assert oc.settings.plot_width == 800
+        assert oc.settings.plot_height == 600
+        assert oc.settings.plot_res == 150
         oc._engine = None
 
     def test_plot_params_kwarg_overrides_settings(self):
@@ -218,8 +218,8 @@ class TestInit:
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py(settings=s, plot_format="svg", plot_width=1024)
-        assert oc.plot_format == "svg"
-        assert oc.plot_width == 1024
+        assert oc.settings.plot_format == "svg"
+        assert oc.settings.plot_width == 1024
         oc._engine = None
 
     def test_plot_params_used_as_eval_defaults(self):
@@ -371,19 +371,19 @@ class TestRestart:
         """When temp_dir is None, restart should create a new temp dir."""
         oc = Oct2Py()
         oc.exit()
-        oc.temp_dir = None
+        oc.settings.temp_dir = None
         oc.restart()
-        assert oc.temp_dir is not None
-        assert os.path.isdir(oc.temp_dir)
+        assert oc.settings.temp_dir is not None
+        assert os.path.isdir(oc.settings.temp_dir)
         oc.exit()
 
     def test_restart_with_temp_dir_set(self):
         """When temp_dir is already set, restart should not change it."""
         temp_dir = tempfile.mkdtemp()
         oc = Oct2Py(temp_dir=temp_dir)
-        original_temp_dir = oc.temp_dir
+        original_temp_dir = oc.settings.temp_dir
         oc.restart()
-        assert oc.temp_dir == original_temp_dir
+        assert oc.settings.temp_dir == original_temp_dir
         oc.exit()
 
     def test_restart_octave_env_var_propagation(self):

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -7,7 +7,229 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from oct2py import Oct2Py, Oct2PyError
+from oct2py import Oct2Py, Oct2PyError, Oct2PySettings
+
+
+class TestInit:
+    """Tests for the new Oct2Py.__init__ parameters."""
+
+    def _make_fake_engine(self, executable="/resolved/octave"):
+        fake = MagicMock()
+        fake.tmp_dir = tempfile.mkdtemp()
+        fake.executable = executable
+        return fake
+
+    # --- settings parameter ---
+
+    def test_settings_applied_as_defaults(self):
+        """Oct2PySettings values fill in unspecified __init__ kwargs."""
+        s = Oct2PySettings(backend="disable", timeout=42, oned_as="column",
+                           convert_to_float=False, keep_matlab_shapes=True)
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py(settings=s)
+        assert oc.backend == "disable"
+        assert oc.timeout == 42
+        assert oc._oned_as == "column"
+        assert oc.convert_to_float is False
+        assert oc.keep_matlab_shapes is True
+        oc._engine = None
+
+    def test_kwargs_override_settings(self):
+        """Explicit __init__ kwargs take precedence over settings values."""
+        s = Oct2PySettings(backend="disable", timeout=99)
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py(settings=s, backend="default", timeout=7)
+        assert oc.backend == "default"
+        assert oc.timeout == 7
+        oc._engine = None
+
+    def test_default_settings_created_when_none(self):
+        """When settings=None, a default Oct2PySettings() is created."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py()
+        assert isinstance(oc._settings, Oct2PySettings)
+        oc._engine = None
+
+    # --- extra_cli_options parameter ---
+
+    def test_extra_cli_options_passed_to_engine(self):
+        """extra_cli_options is forwarded as cli_options to OctaveEngine."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(extra_cli_options="--traditional")
+        assert mock_engine.call_args.kwargs.get("cli_options") == "--traditional"
+        oc._engine = None
+
+    def test_no_extra_cli_options_passes_empty_string(self):
+        """Without extra_cli_options, cli_options is an empty string."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py()
+        assert mock_engine.call_args.kwargs.get("cli_options") == ""
+        oc._engine = None
+
+    def test_extra_cli_options_from_settings(self):
+        """extra_cli_options falls back to the settings value."""
+        s = Oct2PySettings(extra_cli_options="--traditional")
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(settings=s)
+        cli = mock_engine.call_args.kwargs.get("cli_options", "")
+        assert "--traditional" in cli
+        oc._engine = None
+
+    def test_extra_cli_options_kwarg_overrides_settings(self):
+        """extra_cli_options kwarg overrides the settings value."""
+        s = Oct2PySettings(extra_cli_options="--from-settings")
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(settings=s, extra_cli_options="--from-kwarg")
+        cli = mock_engine.call_args.kwargs.get("cli_options", "")
+        assert "--from-kwarg" in cli
+        assert "--from-settings" not in cli
+        oc._engine = None
+
+    # --- executable parameter ---
+
+    def test_executable_passed_to_engine(self):
+        """executable kwarg is forwarded to OctaveEngine."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(executable="/custom/octave")
+        assert mock_engine.call_args.kwargs.get("executable") == "/custom/octave"
+        oc._engine = None
+
+    def test_executable_updated_from_engine(self):
+        """self.executable is updated to the actual path used by the engine."""
+        fake = self._make_fake_engine(executable="/resolved/octave-cli")
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py(executable="/custom/octave")
+        assert oc.executable == "/resolved/octave-cli"
+        oc._engine = None
+
+    def test_executable_from_settings(self):
+        """executable falls back to the settings value."""
+        s = Oct2PySettings(executable="/settings/octave")
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(settings=s)
+        assert mock_engine.call_args.kwargs.get("executable") == "/settings/octave"
+        oc._engine = None
+
+    def test_executable_kwarg_overrides_settings(self):
+        """executable kwarg overrides the settings value."""
+        s = Oct2PySettings(executable="/settings/octave")
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(settings=s, executable="/kwarg/octave")
+        assert mock_engine.call_args.kwargs.get("executable") == "/kwarg/octave"
+        oc._engine = None
+
+    # --- load_octaverc parameter ---
+
+    def test_load_octaverc_default_is_true(self):
+        """load_octaverc defaults to True and is passed to OctaveEngine."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py()
+        assert mock_engine.call_args.kwargs.get("load_octaverc") is True
+        oc._engine = None
+
+    def test_load_octaverc_false_passed_to_engine(self):
+        """load_octaverc=False is forwarded to OctaveEngine."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(load_octaverc=False)
+        assert mock_engine.call_args.kwargs.get("load_octaverc") is False
+        oc._engine = None
+
+    def test_load_octaverc_from_settings(self):
+        """load_octaverc falls back to the settings value."""
+        s = Oct2PySettings(load_octaverc=False)
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(settings=s)
+        assert mock_engine.call_args.kwargs.get("load_octaverc") is False
+        oc._engine = None
+
+    def test_load_octaverc_kwarg_overrides_settings(self):
+        """load_octaverc kwarg overrides the settings value."""
+        s = Oct2PySettings(load_octaverc=False)
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake) as mock_engine:
+            oc = Oct2Py(settings=s, load_octaverc=True)
+        assert mock_engine.call_args.kwargs.get("load_octaverc") is True
+        oc._engine = None
+
+    # --- plot_* parameters ---
+
+    def test_plot_params_defaults(self):
+        """Plot params get their defaults from settings when not specified."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py()
+        assert oc.plot_format == "svg"
+        assert oc.plot_name == "plot"
+        assert oc.plot_width is None
+        assert oc.plot_height is None
+        assert oc.plot_res is None
+        oc._engine = None
+
+    def test_plot_params_from_kwargs(self):
+        """Plot params set via kwargs are stored on the instance."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py(plot_format="png", plot_name="fig",
+                        plot_width=800, plot_height=600, plot_res=150)
+        assert oc.plot_format == "png"
+        assert oc.plot_name == "fig"
+        assert oc.plot_width == 800
+        assert oc.plot_height == 600
+        assert oc.plot_res == 150
+        oc._engine = None
+
+    def test_plot_params_from_settings(self):
+        """Plot params fall back to settings values."""
+        s = Oct2PySettings(plot_format="png", plot_name="fig",
+                           plot_width=800, plot_height=600, plot_res=150)
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py(settings=s)
+        assert oc.plot_format == "png"
+        assert oc.plot_name == "fig"
+        assert oc.plot_width == 800
+        assert oc.plot_height == 600
+        assert oc.plot_res == 150
+        oc._engine = None
+
+    def test_plot_params_kwarg_overrides_settings(self):
+        """Plot param kwargs take precedence over settings."""
+        s = Oct2PySettings(plot_format="png", plot_width=800)
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py(settings=s, plot_format="svg", plot_width=1024)
+        assert oc.plot_format == "svg"
+        assert oc.plot_width == 1024
+        oc._engine = None
+
+    def test_plot_params_used_as_eval_defaults(self):
+        """Instance plot params are used as defaults in eval() calls."""
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oc = Oct2Py(plot_format="png", plot_name="myfig",
+                        plot_width=640, plot_height=480, plot_res=96)
+        with patch.object(oc, "_feval", return_value=None):
+            oc.eval("1+1")
+        engine_settings = fake.plot_settings
+        assert engine_settings["format"] == "png"
+        assert engine_settings["name"] == "myfig"
+        assert engine_settings["width"] == 640
+        assert engine_settings["height"] == 480
+        assert engine_settings["resolution"] == 96
+        oc._engine = None
 
 
 class TestEnterDel:

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -23,8 +23,13 @@ class TestInit:
 
     def test_settings_applied_as_defaults(self):
         """Oct2PySettings values fill in unspecified __init__ kwargs."""
-        s = Oct2PySettings(backend="disable", timeout=42, oned_as="column",
-                           convert_to_float=False, keep_matlab_shapes=True)
+        s = Oct2PySettings(
+            backend="disable",
+            timeout=42,
+            oned_as="column",
+            convert_to_float=False,
+            keep_matlab_shapes=True,
+        )
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py(settings=s)
@@ -182,8 +187,9 @@ class TestInit:
         """Plot params set via kwargs are stored on the instance."""
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
-            oc = Oct2Py(plot_format="png", plot_name="fig",
-                        plot_width=800, plot_height=600, plot_res=150)
+            oc = Oct2Py(
+                plot_format="png", plot_name="fig", plot_width=800, plot_height=600, plot_res=150
+            )
         assert oc.plot_format == "png"
         assert oc.plot_name == "fig"
         assert oc.plot_width == 800
@@ -193,8 +199,9 @@ class TestInit:
 
     def test_plot_params_from_settings(self):
         """Plot params fall back to settings values."""
-        s = Oct2PySettings(plot_format="png", plot_name="fig",
-                           plot_width=800, plot_height=600, plot_res=150)
+        s = Oct2PySettings(
+            plot_format="png", plot_name="fig", plot_width=800, plot_height=600, plot_res=150
+        )
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oc = Oct2Py(settings=s)
@@ -219,8 +226,9 @@ class TestInit:
         """Instance plot params are used as defaults in eval() calls."""
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
-            oc = Oct2Py(plot_format="png", plot_name="myfig",
-                        plot_width=640, plot_height=480, plot_res=96)
+            oc = Oct2Py(
+                plot_format="png", plot_name="myfig", plot_width=640, plot_height=480, plot_res=96
+            )
         with patch.object(oc, "_feval", return_value=None):
             oc.eval("1+1")
         engine_settings = fake.plot_settings

--- a/tests/test_dynamic_branches.py
+++ b/tests/test_dynamic_branches.py
@@ -177,17 +177,18 @@ class TestResetInstancesAfterFork:
         fake_engine.repl = MagicMock()
         fake_engine.repl.terminated = False
 
-        inst = MagicMock(spec=["_engine", "_temp_dir_owner", "temp_dir"])
+        inst = MagicMock(spec=["_engine", "_temp_dir_owner", "_settings"])
         inst._engine = fake_engine
         inst._temp_dir_owner = True
-        inst.temp_dir = "/tmp/fake"  # noqa: S108
+        inst._settings = MagicMock()
+        inst._settings.temp_dir = "/tmp/fake"  # noqa: S108
 
         instances.add(inst)
         try:
             reset()
             assert inst._engine is None
             assert inst._temp_dir_owner is False
-            assert inst.temp_dir is None
+            assert inst._settings.temp_dir is None
             # repl.terminated should have been set to True
             assert fake_engine.repl.terminated is True
         finally:
@@ -198,17 +199,18 @@ class TestResetInstancesAfterFork:
         reset = self._get_reset_fn()
         instances = self._get_instances()
 
-        inst = MagicMock(spec=["_engine", "_temp_dir_owner", "temp_dir"])
+        inst = MagicMock(spec=["_engine", "_temp_dir_owner", "_settings"])
         inst._engine = None
         inst._temp_dir_owner = True
-        inst.temp_dir = "/tmp/fake2"  # noqa: S108
+        inst._settings = MagicMock()
+        inst._settings.temp_dir = "/tmp/fake2"  # noqa: S108
 
         instances.add(inst)
         try:
             reset()
             assert inst._engine is None
             assert inst._temp_dir_owner is False
-            assert inst.temp_dir is None
+            assert inst._settings.temp_dir is None
         finally:
             instances.discard(inst)
 
@@ -222,8 +224,9 @@ class TestResetInstancesAfterFork:
         # Make unregister raise when called with _cleanup
         fake_engine.repl = MagicMock()
 
-        inst = MagicMock(spec=["_engine", "_temp_dir_owner", "temp_dir"])
+        inst = MagicMock(spec=["_engine", "_temp_dir_owner", "_settings"])
         inst._engine = fake_engine
+        inst._settings = MagicMock()
 
         # Patch atexit.unregister to raise for _cleanup to exercise suppress
         original_unregister = atexit.unregister
@@ -249,7 +252,7 @@ class TestResetInstancesAfterFork:
         try:
             reset()
             assert oc._engine is None
-            assert oc.temp_dir is None
+            assert oc.settings.temp_dir is None
         finally:
             # Instance is now dead — don't call exit(), just discard
             pass

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -54,10 +54,10 @@ class TestMisc:
             for item in os.listdir(tests_dir):
                 src = os.path.join(tests_dir, item)
                 if os.path.isfile(src) and item.endswith(".m"):
-                    shutil.copy2(src, cls.oc.temp_dir)
+                    shutil.copy2(src, cls.oc.settings.temp_dir)
                 elif os.path.isdir(src) and item.startswith("@"):
-                    shutil.copytree(src, os.path.join(cls.oc.temp_dir, item))
-            cls.oc.addpath(cls.oc.temp_dir)
+                    shutil.copytree(src, os.path.join(cls.oc.settings.temp_dir, item))
+            cls.oc.addpath(cls.oc.settings.temp_dir)
         else:
             cls.oc.addpath(tests_dir)
 
@@ -226,7 +226,7 @@ class TestMisc:
     def test_plot(self):
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")
-        plot_dir = tempfile.mkdtemp(dir=self.oc.temp_dir).replace("\\", "/")
+        plot_dir = tempfile.mkdtemp(dir=self.oc.settings.temp_dir).replace("\\", "/")
         self.oc.plot([1, 2, 3], plot_dir=plot_dir)
         assert glob.glob("%s/*" % plot_dir)
         assert self.oc.extract_figures(plot_dir)
@@ -258,8 +258,8 @@ class TestMisc:
         """
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")
-        plot_dir = tempfile.mkdtemp(dir=self.oc.temp_dir).replace("\\", "/")
-        m_path = os.path.join(self.oc.temp_dir, "test_plot_inside.m")
+        plot_dir = tempfile.mkdtemp(dir=self.oc.settings.temp_dir).replace("\\", "/")
+        m_path = os.path.join(self.oc.settings.temp_dir, "test_plot_inside.m")
         with open(m_path, "w") as f:
             f.write(
                 "function test_plot_inside()\n"
@@ -379,7 +379,7 @@ class TestMisc:
             assert result == 2
 
             # auto_show must default to False.
-            assert not oc._auto_show
+            assert not oc.settings.auto_show
 
             # make_figures must never be called when backend='disable'.
             with patch.object(oc._engine, "make_figures") as mock_mf:
@@ -449,7 +449,7 @@ class TestMisc:
         assert out == 5
         doc = self.oc.test_nodocstring.__doc__
         assert "user-defined function" in doc or "undocumented function" in doc
-        expected_dir = self.oc.temp_dir if self._flatpak else os.path.dirname(__file__)
+        expected_dir = self.oc.settings.temp_dir if self._flatpak else os.path.dirname(__file__)
         assert expected_dir in doc
 
     def test_func_noexist(self):
@@ -493,7 +493,7 @@ class TestMisc:
         oc.exit()
 
     def test_temp_dir(self):
-        temp_dir = tempfile.mkdtemp(dir=self.oc.temp_dir)
+        temp_dir = tempfile.mkdtemp(dir=self.oc.settings.temp_dir)
         oc = Oct2Py(temp_dir=temp_dir)
         oc.push("a", 1)
         assert len(os.listdir(temp_dir))

--- a/tests/test_octavemagic.py
+++ b/tests/test_octavemagic.py
@@ -28,7 +28,7 @@ def magics(ip, tmp_path):
         mock_oct2py_module.octave = MagicMock()
         m = OctaveMagics(ip)
     mock_oct = MagicMock()
-    mock_oct.temp_dir = str(tmp_path)
+    mock_oct.settings.temp_dir = str(tmp_path)
     mock_oct.eval.return_value = 42
     mock_oct.extract_figures.return_value = []
     m._oct = mock_oct
@@ -109,22 +109,22 @@ def test_octave_width_height_args(magics):
 
 def test_octave_temp_dir_valid(magics):
     """A valid --temp_dir is forwarded to eval."""
-    valid_dir = magics._oct.temp_dir
+    valid_dir = magics._oct.settings.temp_dir
     magics.octave(f"--temp_dir {valid_dir} X = 1", cell=None, local_ns={})
     kwargs = magics._oct.eval.call_args.kwargs
     assert kwargs["temp_dir"] == valid_dir
 
 
 def test_octave_temp_dir_invalid_falls_back(magics):
-    """An invalid --temp_dir path falls back to _oct.temp_dir."""
+    """An invalid --temp_dir path falls back to _oct.settings.temp_dir."""
     magics.octave("--temp_dir /nonexistent/path/xyz X = 1", cell=None, local_ns={})
     kwargs = magics._oct.eval.call_args.kwargs
-    assert kwargs["temp_dir"] == magics._oct.temp_dir
+    assert kwargs["temp_dir"] == magics._oct.settings.temp_dir
 
 
 def test_octave_plot_dir_existing_is_removed(magics):
     """If plot_dir already exists it is cleared before re-creation."""
-    plot_dir = os.path.join(magics._oct.temp_dir, "plots")
+    plot_dir = os.path.join(magics._oct.settings.temp_dir, "plots")
     os.makedirs(plot_dir)
     sentinel = os.path.join(plot_dir, "old_file.png")
     open(sentinel, "w").close()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,135 @@
+"""Tests for Oct2PySettings."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from oct2py import Oct2PySettings
+
+
+class TestOct2PySettings:
+    """Tests for Oct2PySettings field defaults, env var resolution, and aliases."""
+
+    def test_defaults(self):
+        """All fields have the expected defaults when no env vars are set."""
+        env = {k: v for k, v in os.environ.items()
+               if not k.startswith("OCT2PY_") and k not in ("OCTAVE_EXECUTABLE", "OCTAVE")}
+        with patch.dict(os.environ, env, clear=True):
+            s = Oct2PySettings()
+        assert s.executable is None
+        assert s.timeout is None
+        assert s.oned_as == "row"
+        assert s.temp_dir is None
+        assert s.convert_to_float is True
+        assert s.backend == "default"
+        assert s.keep_matlab_shapes is False
+        assert s.auto_show is None
+        assert s.plot_format == "svg"
+        assert s.plot_name == "plot"
+        assert s.plot_width is None
+        assert s.plot_height is None
+        assert s.plot_res is None
+        assert s.extra_cli_options == ""
+
+    # --- OCT2PY_* env vars ---
+
+    def test_oct2py_timeout_env_var(self):
+        """OCT2PY_TIMEOUT sets the timeout field."""
+        with patch.dict(os.environ, {"OCT2PY_TIMEOUT": "60"}):
+            s = Oct2PySettings()
+        assert s.timeout == 60.0
+
+    def test_oct2py_backend_env_var(self):
+        """OCT2PY_BACKEND sets the backend field."""
+        with patch.dict(os.environ, {"OCT2PY_BACKEND": "qt"}):
+            s = Oct2PySettings()
+        assert s.backend == "qt"
+
+    def test_oct2py_oned_as_env_var(self):
+        """OCT2PY_ONED_AS sets the oned_as field."""
+        with patch.dict(os.environ, {"OCT2PY_ONED_AS": "column"}):
+            s = Oct2PySettings()
+        assert s.oned_as == "column"
+
+    def test_oct2py_convert_to_float_env_var(self):
+        """OCT2PY_CONVERT_TO_FLOAT=false disables float conversion."""
+        with patch.dict(os.environ, {"OCT2PY_CONVERT_TO_FLOAT": "false"}):
+            s = Oct2PySettings()
+        assert s.convert_to_float is False
+
+    def test_oct2py_extra_cli_options_env_var(self):
+        """OCT2PY_EXTRA_CLI_OPTIONS sets the extra_cli_options field."""
+        with patch.dict(os.environ, {"OCT2PY_EXTRA_CLI_OPTIONS": "--traditional"}):
+            s = Oct2PySettings()
+        assert s.extra_cli_options == "--traditional"
+
+    # --- executable aliases ---
+
+    def test_octave_executable_env_var(self):
+        """OCTAVE_EXECUTABLE sets the executable field."""
+        env = {k: v for k, v in os.environ.items() if k != "OCTAVE"}
+        env["OCTAVE_EXECUTABLE"] = "/env/octave"
+        with patch.dict(os.environ, env, clear=True):
+            s = Oct2PySettings()
+        assert s.executable == "/env/octave"
+
+    def test_octave_env_var_alias(self):
+        """OCTAVE sets the executable field when OCTAVE_EXECUTABLE is absent."""
+        env = {k: v for k, v in os.environ.items() if k != "OCTAVE_EXECUTABLE"}
+        env["OCTAVE"] = "/alias/octave"
+        with patch.dict(os.environ, env, clear=True):
+            s = Oct2PySettings()
+        assert s.executable == "/alias/octave"
+
+    def test_octave_executable_takes_precedence_over_octave(self):
+        """OCTAVE_EXECUTABLE takes precedence over OCTAVE."""
+        with patch.dict(os.environ, {"OCTAVE_EXECUTABLE": "/primary/octave",
+                                     "OCTAVE": "/fallback/octave"}):
+            s = Oct2PySettings()
+        assert s.executable == "/primary/octave"
+
+    # --- programmatic construction ---
+
+    def test_oct2py_load_octaverc_env_var(self):
+        """OCT2PY_LOAD_OCTAVERC=false disables octaverc loading."""
+        with patch.dict(os.environ, {"OCT2PY_LOAD_OCTAVERC": "false"}):
+            s = Oct2PySettings()
+        assert s.load_octaverc is False
+
+    def test_oct2py_plot_format_env_var(self):
+        """OCT2PY_PLOT_FORMAT sets the plot_format field."""
+        with patch.dict(os.environ, {"OCT2PY_PLOT_FORMAT": "png"}):
+            s = Oct2PySettings()
+        assert s.plot_format == "png"
+
+    def test_oct2py_plot_width_env_var(self):
+        """OCT2PY_PLOT_WIDTH sets the plot_width field."""
+        with patch.dict(os.environ, {"OCT2PY_PLOT_WIDTH": "1280"}):
+            s = Oct2PySettings()
+        assert s.plot_width == 1280
+
+    def test_programmatic_values(self):
+        """Fields can be set directly when constructing the settings object."""
+        s = Oct2PySettings(
+            executable="/prog/octave",
+            timeout=15.0,
+            backend="disable",
+            oned_as="column",
+            extra_cli_options="--traditional",
+            plot_format="png",
+            plot_name="fig",
+            plot_width=800,
+            plot_height=600,
+            plot_res=150,
+        )
+        assert s.executable == "/prog/octave"
+        assert s.timeout == 15.0
+        assert s.backend == "disable"
+        assert s.oned_as == "column"
+        assert s.extra_cli_options == "--traditional"
+        assert s.plot_format == "png"
+        assert s.plot_name == "fig"
+        assert s.plot_width == 800
+        assert s.plot_height == 600
+        assert s.plot_res == 150

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,11 +1,11 @@
-"""Tests for Oct2PySettings."""
+"""Tests for Oct2PySettings and configure()."""
 
 import os
-from unittest.mock import patch
+import tempfile
+from unittest.mock import MagicMock, patch
 
-import pytest
-
-from oct2py import Oct2PySettings
+import oct2py
+from oct2py import Oct2Py, Oct2PySettings
 
 
 class TestOct2PySettings:
@@ -13,8 +13,11 @@ class TestOct2PySettings:
 
     def test_defaults(self):
         """All fields have the expected defaults when no env vars are set."""
-        env = {k: v for k, v in os.environ.items()
-               if not k.startswith("OCT2PY_") and k not in ("OCTAVE_EXECUTABLE", "OCTAVE")}
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.startswith("OCT2PY_") and k not in ("OCTAVE_EXECUTABLE", "OCTAVE")
+        }
         with patch.dict(os.environ, env, clear=True):
             s = Oct2PySettings()
         assert s.executable is None
@@ -84,8 +87,9 @@ class TestOct2PySettings:
 
     def test_octave_executable_takes_precedence_over_octave(self):
         """OCTAVE_EXECUTABLE takes precedence over OCTAVE."""
-        with patch.dict(os.environ, {"OCTAVE_EXECUTABLE": "/primary/octave",
-                                     "OCTAVE": "/fallback/octave"}):
+        with patch.dict(
+            os.environ, {"OCTAVE_EXECUTABLE": "/primary/octave", "OCTAVE": "/fallback/octave"}
+        ):
             s = Oct2PySettings()
         assert s.executable == "/primary/octave"
 
@@ -133,3 +137,97 @@ class TestOct2PySettings:
         assert s.plot_width == 800
         assert s.plot_height == 600
         assert s.plot_res == 150
+
+
+class TestConfigure:
+    """Tests for the oct2py.configure() function."""
+
+    def _make_fake_engine(self, executable="/resolved/octave"):
+        fake = MagicMock()
+        fake.tmp_dir = tempfile.mkdtemp()
+        fake.executable = executable
+        return fake
+
+    def test_configure_with_kwargs_builds_settings(self):
+        """configure(**kwargs) builds an Oct2PySettings from kwargs."""
+        fake = self._make_fake_engine()
+        original = oct2py.octave
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oct2py.configure(backend="disable", timeout=42)
+        new_instance = oct2py.octave
+        assert new_instance is not original
+        assert new_instance.backend == "disable"
+        assert new_instance.timeout == 42
+        new_instance._engine = None
+
+    def test_configure_with_settings_object(self):
+        """configure(settings=s) uses the provided settings object directly."""
+        s = Oct2PySettings(backend="disable", timeout=99, oned_as="column")
+        fake = self._make_fake_engine()
+        original = oct2py.octave
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oct2py.configure(settings=s)
+        new_instance = oct2py.octave
+        assert new_instance is not original
+        assert new_instance.backend == "disable"
+        assert new_instance.timeout == 99
+        assert new_instance._oned_as == "column"
+        new_instance._engine = None
+
+    def test_configure_no_args_uses_defaults(self):
+        """configure() with no args creates a default-settings instance."""
+        fake = self._make_fake_engine()
+        original = oct2py.octave
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oct2py.configure()
+        new_instance = oct2py.octave
+        assert new_instance is not original
+        assert isinstance(new_instance._settings, Oct2PySettings)
+        assert new_instance.backend == "default"
+        new_instance._engine = None
+
+    def test_configure_replaces_global_octave(self):
+        """configure() replaces oct2py.octave with a new Oct2Py instance."""
+        fake = self._make_fake_engine()
+        before = oct2py.octave
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oct2py.configure(backend="disable")
+        assert oct2py.octave is not before
+        assert isinstance(oct2py.octave, Oct2Py)
+        oct2py.octave._engine = None
+
+    def test_configure_exits_old_instance(self):
+        """configure() calls exit() on the previous global octave instance."""
+        fake = self._make_fake_engine()
+        old_instance = MagicMock()
+        with (
+            patch.object(oct2py, "octave", old_instance),
+            patch("oct2py.core.OctaveEngine", return_value=fake),
+        ):
+            oct2py.configure(backend="disable")
+        old_instance.exit.assert_called_once()
+        oct2py.octave._engine = None
+
+    def test_configure_kwargs_override_env_vars(self):
+        """kwargs passed to configure() take precedence over OCT2PY_* env vars."""
+        fake = self._make_fake_engine()
+        with (
+            patch.dict(os.environ, {"OCT2PY_BACKEND": "qt"}),
+            patch("oct2py.core.OctaveEngine", return_value=fake),
+        ):
+            oct2py.configure(backend="disable")
+        assert oct2py.octave.backend == "disable"
+        oct2py.octave._engine = None
+
+    def test_configure_settings_ignored_if_kwargs_provided(self):
+        """When both settings and kwargs are passed, settings wins (kwargs are ignored)."""
+        # The function signature is configure(settings=None, **kwargs).
+        # If a pre-built settings object is passed, kwargs are silently ignored
+        # because Oct2PySettings(**kwargs) is only called when settings is None.
+        s = Oct2PySettings(backend="disable")
+        fake = self._make_fake_engine()
+        with patch("oct2py.core.OctaveEngine", return_value=fake):
+            oct2py.configure(settings=s, timeout=77)
+        # timeout=77 is not applied — it was passed as a kwarg but settings was provided
+        assert oct2py.octave._settings is s
+        oct2py.octave._engine = None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,6 +4,8 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import oct2py
 from oct2py import Oct2Py, Oct2PySettings
 
@@ -139,6 +141,22 @@ class TestOct2PySettings:
         assert s.plot_res == 150
 
 
+@pytest.fixture()
+def restore_octave():
+    """Save and restore oct2py.octave after each configure test.
+
+    Also mocks exit() on the saved instance so the real Octave session is
+    never closed by configure() during a test.
+    """
+    saved = oct2py.octave
+    with patch.object(saved, "exit"):
+        yield
+    # Null out the engine of whatever configure() installed, then restore.
+    if oct2py.octave is not saved:
+        oct2py.octave._engine = None
+    oct2py.octave = saved
+
+
 class TestConfigure:
     """Tests for the oct2py.configure() function."""
 
@@ -148,7 +166,7 @@ class TestConfigure:
         fake.executable = executable
         return fake
 
-    def test_configure_with_kwargs_builds_settings(self):
+    def test_configure_with_kwargs_builds_settings(self, restore_octave):
         """configure(**kwargs) builds an Oct2PySettings from kwargs."""
         fake = self._make_fake_engine()
         original = oct2py.octave
@@ -158,9 +176,8 @@ class TestConfigure:
         assert new_instance is not original
         assert new_instance.backend == "disable"
         assert new_instance.timeout == 42
-        new_instance._engine = None
 
-    def test_configure_with_settings_object(self):
+    def test_configure_with_settings_object(self, restore_octave):
         """configure(settings=s) uses the provided settings object directly."""
         s = Oct2PySettings(backend="disable", timeout=99, oned_as="column")
         fake = self._make_fake_engine()
@@ -172,9 +189,8 @@ class TestConfigure:
         assert new_instance.backend == "disable"
         assert new_instance.timeout == 99
         assert new_instance._oned_as == "column"
-        new_instance._engine = None
 
-    def test_configure_no_args_uses_defaults(self):
+    def test_configure_no_args_uses_defaults(self, restore_octave):
         """configure() with no args creates a default-settings instance."""
         fake = self._make_fake_engine()
         original = oct2py.octave
@@ -184,9 +200,8 @@ class TestConfigure:
         assert new_instance is not original
         assert isinstance(new_instance._settings, Oct2PySettings)
         assert new_instance.backend == "default"
-        new_instance._engine = None
 
-    def test_configure_replaces_global_octave(self):
+    def test_configure_replaces_global_octave(self, restore_octave):
         """configure() replaces oct2py.octave with a new Oct2Py instance."""
         fake = self._make_fake_engine()
         before = oct2py.octave
@@ -194,21 +209,20 @@ class TestConfigure:
             oct2py.configure(backend="disable")
         assert oct2py.octave is not before
         assert isinstance(oct2py.octave, Oct2Py)
-        oct2py.octave._engine = None
 
     def test_configure_exits_old_instance(self):
         """configure() calls exit() on the previous global octave instance."""
         fake = self._make_fake_engine()
         old_instance = MagicMock()
+        # patch.object restores oct2py.octave on exit, so the real session is unaffected.
         with (
             patch.object(oct2py, "octave", old_instance),
             patch("oct2py.core.OctaveEngine", return_value=fake),
         ):
             oct2py.configure(backend="disable")
         old_instance.exit.assert_called_once()
-        oct2py.octave._engine = None
 
-    def test_configure_kwargs_override_env_vars(self):
+    def test_configure_kwargs_override_env_vars(self, restore_octave):
         """kwargs passed to configure() take precedence over OCT2PY_* env vars."""
         fake = self._make_fake_engine()
         with (
@@ -217,9 +231,8 @@ class TestConfigure:
         ):
             oct2py.configure(backend="disable")
         assert oct2py.octave.backend == "disable"
-        oct2py.octave._engine = None
 
-    def test_configure_settings_ignored_if_kwargs_provided(self):
+    def test_configure_settings_ignored_if_kwargs_provided(self, restore_octave):
         """When both settings and kwargs are passed, settings wins (kwargs are ignored)."""
         # The function signature is configure(settings=None, **kwargs).
         # If a pre-built settings object is passed, kwargs are silently ignored
@@ -230,4 +243,3 @@ class TestConfigure:
             oct2py.configure(settings=s, timeout=77)
         # timeout=77 is not applied — it was passed as a kwarg but settings was provided
         assert oct2py.octave._settings is s
-        oct2py.octave._engine = None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -174,8 +174,8 @@ class TestConfigure:
             oct2py.configure(backend="disable", timeout=42)
         new_instance = oct2py.octave
         assert new_instance is not original
-        assert new_instance.backend == "disable"
-        assert new_instance.timeout == 42
+        assert new_instance.settings.backend == "disable"
+        assert new_instance.settings.timeout == 42
 
     def test_configure_with_settings_object(self, restore_octave):
         """configure(settings=s) uses the provided settings object directly."""
@@ -186,9 +186,9 @@ class TestConfigure:
             oct2py.configure(settings=s)
         new_instance = oct2py.octave
         assert new_instance is not original
-        assert new_instance.backend == "disable"
-        assert new_instance.timeout == 99
-        assert new_instance._oned_as == "column"
+        assert new_instance.settings.backend == "disable"
+        assert new_instance.settings.timeout == 99
+        assert new_instance.settings.oned_as == "column"
 
     def test_configure_no_args_uses_defaults(self, restore_octave):
         """configure() with no args creates a default-settings instance."""
@@ -198,8 +198,8 @@ class TestConfigure:
             oct2py.configure()
         new_instance = oct2py.octave
         assert new_instance is not original
-        assert isinstance(new_instance._settings, Oct2PySettings)
-        assert new_instance.backend == "default"
+        assert isinstance(new_instance.settings, Oct2PySettings)
+        assert new_instance.settings.backend == "default"
 
     def test_configure_replaces_global_octave(self, restore_octave):
         """configure() replaces oct2py.octave with a new Oct2Py instance."""
@@ -230,7 +230,7 @@ class TestConfigure:
             patch("oct2py.core.OctaveEngine", return_value=fake),
         ):
             oct2py.configure(backend="disable")
-        assert oct2py.octave.backend == "disable"
+        assert oct2py.octave.settings.backend == "disable"
 
     def test_configure_settings_ignored_if_kwargs_provided(self, restore_octave):
         """When both settings and kwargs are passed, settings wins (kwargs are ignored)."""
@@ -241,5 +241,7 @@ class TestConfigure:
         fake = self._make_fake_engine()
         with patch("oct2py.core.OctaveEngine", return_value=fake):
             oct2py.configure(settings=s, timeout=77)
-        # timeout=77 is not applied — it was passed as a kwarg but settings was provided
-        assert oct2py.octave._settings is s
+        # timeout=77 is not applied — it was passed as a kwarg but settings was provided.
+        # The instance settings are derived from s, so backend is preserved.
+        assert oct2py.octave.settings.backend == "disable"
+        assert oct2py.octave.settings.timeout != 77

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -42,7 +42,7 @@ class TestUsage:
         # Write the script into temp_dir so sandboxed Octave (snap/flatpak)
         # can access it.
         with tempfile.NamedTemporaryFile(
-            suffix=".m", mode="w", delete=False, dir=self.oc.temp_dir
+            suffix=".m", mode="w", delete=False, dir=self.oc.settings.temp_dir
         ) as f:
             f.write("issue239_var = [1, 2, 3];")
             script_path = f.name

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2006,6 +2015,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "octave-kernel" },
+    { name = "pydantic-settings" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
@@ -2075,7 +2085,8 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.24" },
-    { name = "octave-kernel", specifier = ">=0.39" },
+    { name = "octave-kernel", specifier = ">=1.0.0rc0" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "scipy", specifier = ">=1.9.0" },
 ]
 
@@ -2134,16 +2145,16 @@ typing = [
 
 [[package]]
 name = "octave-kernel"
-version = "0.39.0"
+version = "1.0.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipykernel" },
     { name = "jupyter-client" },
     { name = "metakernel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/f6/c044883eaff44b31984d8a3090c903376c478d409fa07c5a9a0ac7003ea4/octave_kernel-0.39.0.tar.gz", hash = "sha256:384390c28c5911c78aeb746e6e2eeefc6492f4878356c75ef5c0cc99c0e719f4", size = 265903, upload-time = "2026-03-09T12:46:25.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c7/2ac295235905203c39b4eb273d86bd97721a5ae8fe17a13633a2fe0d52b3/octave_kernel-1.0.0rc0.tar.gz", hash = "sha256:ca061d588cb274dde8b52a8e44cef036b9ba627d465ac008e12ab5d278093c29", size = 554534, upload-time = "2026-03-16T11:54:53.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/10/e88bfa82e0da89d0a3a2d0fcb9e9f0822ab23713a17b2c74c37dc7068ffd/octave_kernel-0.39.0-py3-none-any.whl", hash = "sha256:693c40c473dbc1f3442b7e3afdb03f6858bcfa5d484a643028fd8ca7231927c2", size = 36537, upload-time = "2026-03-09T12:46:23.526Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/10/a1cd3e0e1b4d80354731b9600e8fc642580c90ae59e1933d14ff631960d1/octave_kernel-1.0.0rc0-py3-none-any.whl", hash = "sha256:2327461d4146ce0ef794d66393884c27e47fc3804322e9193ec2d9f82da7976d", size = 40874, upload-time = "2026-03-16T11:54:51.58Z" },
 ]
 
 [[package]]
@@ -2531,6 +2542,153 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2661,6 +2819,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d7/7e/9f3b0dd3a074a6c3e1e79f35e465b1f2ee4b262d619de00cfce523cc9b24/python_discovery-1.1.3.tar.gz", hash = "sha256:7acca36e818cd88e9b2ba03e045ad7e93e1713e29c6bbfba5d90202310b7baa5", size = 56945, upload-time = "2026-03-10T15:08:15.038Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl", hash = "sha256:90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e", size = 31485, upload-time = "2026-03-10T15:08:13.06Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -3277,6 +3444,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `Oct2PySettings(BaseSettings)` — a single config object that reads all session defaults from `OCT2PY_*` environment variables, a `.env` file, or programmatic construction
- Every `Oct2Py.__init__` parameter (`executable`, `timeout`, `backend`, `load_octaverc`, `plot_format`, etc.) now has a matching settings field; individual kwargs still take precedence over settings
- Adds `oct2py.configure(**kwargs)` to reconfigure the global `octave` instance without restarting Python
- Bumps `octave_kernel` requirement to `>= 1.0.0rc0`; drops manual `--no-line-editing` flag (now handled internally by octave_kernel) and picks up the new `load_octaverc` parameter
- New `Configuration & Settings` docs page with recipes, env var reference table, and `.env` file support

## Test plan

- [x] `uv run pytest tests/test_core_branches.py::TestInit` — all new `__init__` parameter tests pass
- [x] `uv run pytest tests/test_settings.py` — env var resolution and alias tests pass
- [x] `uv run pytest tests/test_core_branches.py tests/test_settings.py` — full suite of new tests green
- [x] `uv run --group docs mkdocs build --strict` — docs build cleanly with no warnings