### PR TITLE
Add check() diagnostic utility, debugging docs, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug Report
+description: Report a bug to help us improve oct2py
+title: "[Bug] Short summary of the bug - Component"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened. Include the full error message and traceback.
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Run `python -m oct2py.check` and paste the output here.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Low
+        - Medium
+        - High
+        - Critical
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Suggest an enhancement or new feature for oct2py
+title: "[Feature] Short description of the enhancement"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature or enhancement.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Is your feature request related to a problem? A clear and concise description of what the problem is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you have considered.
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: User Value / Impact
+      description: Who will benefit from this feature? How does it improve the user experience?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or examples about the feature request here.

--- a/docs/info.md
+++ b/docs/info.md
@@ -226,6 +226,52 @@ All Oct2Py methods support a `verbose` keyword. If True, the commands
 are logged at the INFO level, otherwise they are logged at the DEBUG
 level.
 
+## Debugging
+
+When troubleshooting an installation or unexpected behaviour, use
+`oct2py.check()` to print a snapshot of your environment:
+
+```pycon
+>>> import oct2py
+>>> oct2py.check()  # doctest: +SKIP
+Platform:     Linux 6.8.0 (x86_64)
+Python:       3.11.9 (main, Apr  2 2024, 08:55:17) [GCC 11.4.0]
+Python path:  /usr/bin/python3
+
+oct2py:       5.8.0
+numpy:        2.2.6
+scipy:        1.15.3
+octave_kernel:0.39.0
+
+Octave exe:   /usr/bin/octave-cli
+
+Connecting to Octave...
+Octave:       9.2.0
+Graphics:     qt (available: gnuplot, qt)
+Connection OK
+```
+
+The output includes:
+
+- **Platform / Python** — OS, architecture, Python version, and executable
+  path, useful for confirming which environment is active.
+- **Dependency versions** — `oct2py`, `numpy`, `scipy`, and `octave_kernel`.
+  Version mismatches here are a common source of serialisation errors.
+- **Octave executable** — the resolved path to the Octave binary. If this
+  shows `(not found)`, Octave is not on `PATH` and you need to install it or
+  set the `OCTAVE_EXECUTABLE` environment variable.
+- **Live connection test** — starts an Octave session and reports the Octave
+  version plus the active and available graphics toolkits. A `Connection failed` line here points to a problem with the Octave installation itself
+  rather than the Python side.
+
+You can also run it directly from the command line:
+
+```shell
+python -m oct2py.check
+```
+
+Include the full output when filing a bug report.
+
 ## Shadowed Function Names
 
 If you'd like to call an Octave function that is also an Oct2Py method,

--- a/oct2py/__init__.py
+++ b/oct2py/__init__.py
@@ -24,6 +24,7 @@ trust a code translator, this is your library.
 from .utils import Oct2PyError, get_log  # noqa
 
 from ._version import __version__
+from .check import check
 from .core import Oct2Py, OctaveWorkspaceProxy
 from .demo import demo
 from .io import Cell, Struct, StructArray
@@ -38,6 +39,7 @@ __all__ = [
     "Struct",
     "StructArray",
     "__version__",
+    "check",
     "demo",
     "get_log",
     "octave",

--- a/oct2py/check.py
+++ b/oct2py/check.py
@@ -57,7 +57,7 @@ def check() -> None:
         print(f"Graphics:     {toolkit} (available: {toolkits_str})")
         oc.exit()
         print("Connection OK")
-    except Exception as e:
+    except Exception as e:  # pragma: no cover
         print(f"Connection failed: {e}")
 
 

--- a/oct2py/check.py
+++ b/oct2py/check.py
@@ -1,0 +1,65 @@
+"""oct2py system and dependency check."""
+# Copyright (c) oct2py developers.
+# Distributed under the terms of the MIT License.
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import sys
+from importlib.metadata import version
+
+from ._version import __version__
+
+
+def check() -> None:
+    """Print system and dependency information for oct2py.
+
+    Displays Python environment details, oct2py and dependency versions,
+    Octave executable location, and a live connection test including
+    Octave version and available graphics toolkits.
+
+    Examples
+    --------
+    >>> from oct2py.check import check
+    >>> check()  # doctest: +SKIP
+
+    """
+    print(f"Platform:     {platform.system()} {platform.release()} ({platform.machine()})")
+    print(f"Python:       {sys.version}")
+    print(f"Python path:  {sys.executable}")
+    print()
+    print(f"oct2py:       {__version__}")
+    print(f"numpy:        {version('numpy')}")
+    print(f"scipy:        {version('scipy')}")
+    print(f"octave_kernel:{version('octave_kernel')}")
+    print()
+
+    executable = (
+        os.environ.get("OCTAVE_EXECUTABLE") or shutil.which("octave-cli") or shutil.which("octave")
+    )
+    print(f"Octave exe:   {executable or '(not found)'}")
+    print()
+
+    print("Connecting to Octave...")
+    try:
+        from .core import Oct2Py  # noqa: PLC0415
+
+        oc = Oct2Py()
+        octave_ver = oc.eval("version", verbose=False)
+        print(f"Octave:       {octave_ver}")
+        toolkit = oc.eval("graphics_toolkit", verbose=False)
+        toolkits = oc.eval("available_graphics_toolkits", verbose=False)
+        toolkits_str = (
+            ", ".join(str(t) for t in toolkits.flat) if hasattr(toolkits, "flat") else str(toolkits)
+        )
+        print(f"Graphics:     {toolkit} (available: {toolkits_str})")
+        oc.exit()
+        print("Connection OK")
+    except Exception as e:
+        print(f"Connection failed: {e}")
+
+
+if __name__ == "__main__":
+    check()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ ignore = [
 # PLR0912 Too many branches
 "tests/*" = ["S101", "N806", "PLR2004", "SIM114",
               "PLR0912", "RUF059", "E721", "PLC0415", "EM101"]
+"oct2py/check.py" = ["T201"]
 "*.ipynb" = ["B018", "T201", "F821"]
 
 [tool.interrogate]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -223,6 +223,16 @@ class TestMisc:
         except TypeError:
             speed_check.speed_check()  # type:ignore[attr-defined]
 
+    def test_check(self, capsys):
+        from oct2py import check
+
+        check()
+        out = capsys.readouterr().out
+        assert "Platform:" in out
+        assert "oct2py:" in out
+        assert "Octave exe:" in out
+        assert "Connection OK" in out
+
     def test_plot(self):
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")


### PR DESCRIPTION
## References

<!-- no related issue -->

## Description

Adds a `check()` diagnostic function, documentation for debugging with it, and structured GitHub issue templates.

## Changes

- **`oct2py/check.py`**: New `check()` function (and `python -m oct2py.check` entry point) that prints platform/Python info, dependency versions (`oct2py`, `numpy`, `scipy`, `octave_kernel`), resolved Octave executable path, and a live connection test showing Octave version and graphics toolkits
- **`oct2py/__init__.py`**: Export `check` from the top-level package
- **`docs/info.md`**: New "Debugging" section explaining each line of `check()` output and directing users to include it in bug reports
- **`.github/ISSUE_TEMPLATE/bug_report.yml`**: Structured bug report form (GitHub issue forms) with required fields including an `oct2py.check` output field
- **`.github/ISSUE_TEMPLATE/feature_request.yml`**: Structured feature request form
- **`pyproject.toml`**: Exempt `oct2py/check.py` from the T201 (print) lint rule

## Backwards-incompatible changes

None

## Testing

Manually verified `python -m oct2py.check` output. All pre-commit hooks pass.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code