### PR TITLE
Fix logging/warning hygiene: remove NullHandler, add Oct2PyWarning

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,10 @@ jupyter:
 
 ::: oct2py.Oct2PyError
 
+## Oct2PyWarning
+
+::: oct2py.Oct2PyWarning
+
 ## get_log
 
 ::: oct2py.get_log

--- a/docs/info.md
+++ b/docs/info.md
@@ -178,17 +178,22 @@ version of Octave.
 ## Logging
 
 Oct2Py uses the standard Python `logging` module under the logger name
-`"oct2py"`. Following Python library best practices, no handlers or levels
-are configured by default — all log output is suppressed unless your
-application sets up logging.
+`"oct2py"`. Following Python library best practices, oct2py installs no
+handlers and sets no log levels. This means:
 
-To see oct2py log output, configure the `"oct2py"` logger (or the root
-logger) in your application:
+- **WARNING and above** propagate to the root logger. If your application has
+  not configured logging, Python's built-in `lastResort` handler will print
+  them to `stderr`.
+- **DEBUG and INFO** are invisible until you configure logging, since the root
+  logger's default level is WARNING.
+
+To see oct2py INFO output (e.g. commands sent to Octave), configure the
+`"oct2py"` logger or the root logger in your application:
 
 ```python
 import logging
 
-# Show INFO and above from oct2py
+# Show INFO and above from oct2py only
 logging.getLogger("oct2py").setLevel(logging.INFO)
 logging.getLogger("oct2py").addHandler(logging.StreamHandler())
 
@@ -225,6 +230,40 @@ it at any time:
 All Oct2Py methods support a `verbose` keyword. If True, the commands
 are logged at the INFO level, otherwise they are logged at the DEBUG
 level.
+
+## Warnings
+
+Oct2Py uses `Oct2PyWarning` (a subclass of `UserWarning`) for deprecation
+notices and other advisory conditions. Because it has its own type, you can
+handle oct2py warnings independently of warnings from other libraries.
+
+Catch oct2py warnings in tests with `pytest.warns`:
+
+```python
+import pytest
+from oct2py import Oct2PyWarning
+
+with pytest.warns(Oct2PyWarning):
+    oc.eval("1 + 1", log=False)  # log= kwarg is deprecated
+```
+
+Silence oct2py warnings without affecting other `UserWarning`s:
+
+```python
+import warnings
+from oct2py import Oct2PyWarning
+
+warnings.filterwarnings("ignore", category=Oct2PyWarning)
+```
+
+Turn oct2py warnings into errors (useful in CI):
+
+```python
+import warnings
+from oct2py import Oct2PyWarning
+
+warnings.filterwarnings("error", category=Oct2PyWarning)
+```
 
 ## Debugging
 

--- a/oct2py/__init__.py
+++ b/oct2py/__init__.py
@@ -21,7 +21,7 @@ If you want to run legacy m-files, do not have MATLAB(TM), and do not fully
 trust a code translator, this is your library.
 """
 
-from .utils import Oct2PyError, get_log  # noqa
+from .utils import Oct2PyError, Oct2PyWarning, get_log  # noqa
 
 from ._version import __version__
 from .check import check
@@ -35,6 +35,7 @@ __all__ = [
     "Cell",
     "Oct2Py",
     "Oct2PyError",
+    "Oct2PyWarning",
     "OctaveWorkspaceProxy",
     "Struct",
     "StructArray",

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -29,7 +29,7 @@ from .dynamic import (
     _make_variable_ptr_instance,
 )
 from .io import Cell, StructArray, read_file, write_file
-from .utils import Oct2PyError, _augment_path_for_windows, get_log
+from .utils import Oct2PyError, Oct2PyWarning, _augment_path_for_windows, get_log
 
 HERE = osp.realpath(osp.dirname(__file__))
 
@@ -754,7 +754,7 @@ class Oct2Py:
             if name not in kwargs:
                 continue
             msg = "Using deprecated `%s` kwarg, see docs on `Oct2Py.eval()`"
-            warnings.warn(msg % name, stacklevel=2)
+            warnings.warn(msg % name, Oct2PyWarning, stacklevel=2)
 
         return_both = kwargs.pop("return_both", False)
         lines: list[str] = []

--- a/oct2py/dynamic.py
+++ b/oct2py/dynamic.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import numpy as np
 
+from .utils import Oct2PyWarning
+
 try:
     from scipy.io.matlab import MatlabObject
 except ImportError:  # pragma: no cover
@@ -103,7 +105,9 @@ class OctaveFunctionPtr(OctavePtr):
                 extras[key] = kwargs.pop(key)
 
         if extras:
-            warnings.warn("Key - value pairs are deprecated, use `func_args`", stacklevel=2)
+            warnings.warn(
+                "Key - value pairs are deprecated, use `func_args`", Oct2PyWarning, stacklevel=2
+            )
 
         inputs += tuple(item for pair in extras.items() for item in pair)
 

--- a/oct2py/utils.py
+++ b/oct2py/utils.py
@@ -12,6 +12,12 @@ class Oct2PyError(Exception):
     pass
 
 
+class Oct2PyWarning(UserWarning):
+    """Warning raised by oct2py for deprecations and other advisory conditions."""
+
+    pass
+
+
 def get_log(name=None):
     """Return a logger for oct2py.
 
@@ -30,12 +36,6 @@ def get_log(name=None):
     """
     name = "oct2py" if name is None else "oct2py." + name
     return logging.getLogger(name)
-
-
-# Add a NullHandler so that log records are silently discarded unless the
-# application configures logging.  Per Python logging best practices, libraries
-# must not install their own handlers or set levels on their loggers.
-logging.getLogger("oct2py").addHandler(logging.NullHandler())
 
 
 def _augment_path_for_windows(executable: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,8 @@ filterwarnings= [
   # Fail on warnings
   "error",
   # Ignore our own user warnings
-  "ignore:Using deprecated:oct2py.Oct2PyWarning:tests",
-  "ignore:Key - value pairs:oct2py.Oct2PyWarning:tests",
+  "ignore:Using deprecated:UserWarning:tests",
+  "ignore:Key - value pairs:UserWarning:tests",
   "module:Jupyter is migrating its paths:DeprecationWarning",
   "module:datetime.datetime.utcf:DeprecationWarning",
   "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # pandas pyarrow (pandas<3.0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,8 @@ filterwarnings= [
   # Fail on warnings
   "error",
   # Ignore our own user warnings
-  "ignore:Using deprecated:UserWarning:tests",
-  "ignore:Key - value pairs:UserWarning:tests",
+  "ignore:Using deprecated:oct2py.Oct2PyWarning:tests",
+  "ignore:Key - value pairs:oct2py.Oct2PyWarning:tests",
   "module:Jupyter is migrating its paths:DeprecationWarning",
   "module:datetime.datetime.utcf:DeprecationWarning",
   "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # pandas pyarrow (pandas<3.0),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,6 +6,7 @@ import shutil
 import signal
 import sys
 import tempfile
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import StringIO
 
@@ -14,7 +15,7 @@ import pandas as pd
 import pytest
 
 import oct2py
-from oct2py import Oct2Py, Oct2PyError, StructArray
+from oct2py import Oct2Py, Oct2PyError, Oct2PyWarning, StructArray
 
 
 def _multiprocessing_worker(_):
@@ -145,6 +146,52 @@ class TestMisc:
         assert 'exist("zeros")' in resp
         assert 'exist("ones")' not in resp
         assert "_pyeval(" in resp
+
+    def test_no_null_handler(self):
+        # Libraries must not install a NullHandler — it was removed in the fix
+        # for issue #162.  Without it, WARNING+ records propagate to the root
+        # logger (and ultimately to logging.lastResort → stderr) when the
+        # application has not configured logging.
+        logger = logging.getLogger("oct2py")
+        null_handlers = [h for h in logger.handlers if isinstance(h, logging.NullHandler)]
+        assert null_handlers == [], "oct2py must not install a NullHandler"
+        assert logger.propagate is True
+
+    def test_warning_propagates_to_root(self):
+        # With no NullHandler, a WARNING emitted on the oct2py logger must
+        # reach the root logger so that logging.lastResort can display it.
+        oct2py_logger = logging.getLogger("oct2py")
+        root_logger = logging.getLogger()
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Capture(logging.WARNING)
+        root_logger.addHandler(handler)
+        try:
+            oct2py_logger.warning("oct2py-sentinel")
+        finally:
+            root_logger.removeHandler(handler)
+
+        assert any("oct2py-sentinel" in r.getMessage() for r in records)
+
+    def test_oct2py_warning_raised(self):
+        # Deprecated kwargs on eval() must surface as Oct2PyWarning.
+        with pytest.warns(Oct2PyWarning, match="deprecated `log`"):
+            self.oc.eval("1 + 1", log=False)
+
+    def test_oct2py_warning_filterable(self):
+        # Oct2PyWarning can be silenced without affecting unrelated UserWarnings.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warnings.filterwarnings("ignore", category=Oct2PyWarning)
+            self.oc.eval("1 + 1", log=False)
+            warnings.warn("unrelated", UserWarning, stacklevel=1)
+
+        assert not any(issubclass(w.category, Oct2PyWarning) for w in caught)
+        assert any(w.category is UserWarning for w in caught)
 
     def test_demo(self):
         if self._flatpak:


### PR DESCRIPTION
## References

Closes #162

## Description

Two related fixes for library logging/warning hygiene:

1. **Remove `NullHandler`** from the `oct2py` logger. With `NullHandler` installed, all log records (including WARNING+) were silently discarded even when the application hadn't configured logging. Removing it restores Python's default behaviour: WARNING and above propagate to the root logger and appear on stderr via `logging.lastResort` when no handlers are configured.

2. **Add `Oct2PyWarning`** — a `UserWarning` subclass used for all oct2py deprecation notices. Both existing `warnings.warn()` call sites now pass `Oct2PyWarning` as the category, letting users filter oct2py warnings independently of other libraries.

## Changes

- Remove `logging.getLogger("oct2py").addHandler(logging.NullHandler())` from `utils.py`
- Add `Oct2PyWarning(UserWarning)` to `utils.py`; export from `__init__.py`
- Update `warnings.warn()` in `core.py` and `dynamic.py` to use `Oct2PyWarning`
- Update `pyproject.toml` filterwarnings to reference `oct2py.Oct2PyWarning` explicitly
- Add four tests: no-NullHandler assertion, lastResort propagation, warning raised, warning filterable
- Update docs: logging section reflects new default behaviour; new Warnings section with filter examples
- Add `Oct2PyWarning` to API reference

## Backwards-incompatible changes

`Oct2PyWarning` is now the category for deprecation warnings. Code that filtered `UserWarning` by message pattern will continue to work (since `Oct2PyWarning` is a subclass), but code that checked `w.category is UserWarning` exactly will no longer match.

## Testing

`just test` — 207 passed, 8 skipped, 2 xfailed.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code