### PR TITLE
Add opt-in macOS RAM disk and reuse writer.mat file handle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,16 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            install-type: ubuntu
-            cover-cmd: just cover
-          - os: windows-latest
-            install-type: windows
-            cover-cmd: just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py
-          - os: macos-latest
-            install-type: macos
-            cover-cmd: just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 
     steps:
@@ -72,12 +63,12 @@ jobs:
       - name: Install Octave
         uses: calysto/octave_kernel@72a4e04a25ecd24b4d143782fb2313ef384f3e6b # v0.39.0
         with:
-          install-type: ${{ matrix.install-type }}
+          install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Install signal package
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt-get install -qq octave-signal
       - name: Generate coverage report
-        run: ${{ matrix.cover-cmd }}
+        run: ${{ startsWith(matrix.os, 'ubuntu') && 'just cover' || 'just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py' }}
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,9 @@ jobs:
           - os: windows-latest
             install-type: windows
             cover-cmd: just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py
+          - os: macos-latest
+            install-type: macos
+            cover-cmd: just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py
       fail-fast: false
 
     steps:
@@ -89,8 +92,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
-            install-type: macos
           - os: ubuntu-latest
             install-type: ubuntu-flatpak
           - os: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,10 @@
 codecov:
   notify:
-    # Wait for both coverage uploads before reporting:
+    # Wait for all three coverage uploads before reporting:
     # 1 cover (ubuntu-latest, Python 3.10) +
-    # 1 cover (windows-latest, Python 3.10)
-    after_n_builds: 2
+    # 1 cover (windows-latest, Python 3.10) +
+    # 1 cover (macos-latest, Python 3.10)
+    after_n_builds: 3
 
 coverage:
   status:

--- a/docs/info.md
+++ b/docs/info.md
@@ -534,6 +534,51 @@ Oct2Py speed test
 ...
 ```
 
+### Reducing MAT-file overhead with a RAM-backed temp directory
+
+Oct2py exchanges data with Octave by writing and reading MAT files in a
+temporary directory. Keeping that directory in RAM eliminates disk I/O
+entirely and can meaningfully improve throughput for workloads that make
+many short calls.
+
+**Linux** — `/dev/shm` (a kernel-managed tmpfs) is used automatically
+whenever it is available and writable. No configuration is required.
+
+**macOS — opt-in RAM disk (managed by oct2py)**
+
+Pass `ramdisk_size_mb` to have oct2py create, use, and destroy a HFS+
+RAM disk for the duration of the session:
+
+```python
+from oct2py import Oct2Py
+
+oc = Oct2Py(ramdisk_size_mb=256)   # 256 MiB RAM disk
+```
+
+You can also set it via the environment variable `OCT2PY_RAMDISK_SIZE_MB`.
+Choose a size large enough to hold the largest single argument or return
+value you expect to exchange. The disk is unmounted automatically when
+`oc.exit()` is called or when the Python process exits.
+
+**macOS — existing RAM disk (user-managed)**
+
+If you already have a RAM disk mounted (for example via a login-item
+script), pass its path directly as `temp_dir`:
+
+```bash
+# Create a 256 MiB RAM disk and mount it at /Volumes/ramdisk
+diskutil erasevolume HFS+ "ramdisk" $(hdiutil attach -nomount ram://524288)
+```
+
+```python
+from oct2py import Oct2Py
+
+oc = Oct2Py(temp_dir="/Volumes/ramdisk")
+```
+
+oct2py will create a subdirectory inside that path and will *not* unmount
+the disk when the session exits — lifetime management is left to you.
+
 ## Threading
 
 If you want to use threading, you *must* create a new `Oct2Py` instance

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -10,6 +10,7 @@ import os
 import os.path as osp
 import shutil
 import signal
+import sys
 import tempfile
 import threading
 import uuid
@@ -30,7 +31,14 @@ from .dynamic import (
 )
 from .io import Cell, StructArray, read_file, write_file
 from .settings import Oct2PySettings
-from .utils import Oct2PyError, Oct2PyWarning, _augment_path_for_windows, get_log
+from .utils import (
+    Oct2PyError,
+    Oct2PyWarning,
+    _augment_path_for_windows,
+    _create_macos_ramdisk,
+    _detach_macos_ramdisk,
+    get_log,
+)
 
 HERE = osp.realpath(osp.dirname(__file__))
 
@@ -183,6 +191,13 @@ class Oct2Py:
         Default plot height in pixels.
     plot_res : int, optional
         Default plot resolution in pixels per inch.
+    ramdisk_size_mb : int, optional
+        macOS only.  When set to a positive integer, oct2py will create
+        a temporary HFS+ RAM disk of the given size (in MiB) and use it
+        as the MAT-file exchange directory.  The disk is unmounted
+        automatically on session exit.  Has no effect on Linux (where
+        ``/dev/shm`` is used automatically) or on Windows.  Defaults to
+        ``0`` (disabled).
     """
 
     def __init__(  # noqa
@@ -204,6 +219,7 @@ class Oct2Py:
         plot_width=None,
         plot_height=None,
         plot_res=None,
+        ramdisk_size_mb=None,
     ):
         if settings is None:
             settings = Oct2PySettings()
@@ -225,6 +241,8 @@ class Oct2Py:
         self._logger = None
         self.logger = logger
         self._temp_dir_owner = False
+        self._ramdisk_device = None
+        self._out_fh = None
         self._user_classes = {}
         self._function_ptrs = {}
         _instances.add(self)
@@ -274,10 +292,16 @@ class Oct2Py:
                 atexit.unregister(self._engine._cleanup)
             self._engine.repl.terminate()
         self._engine = None
+        if self._out_fh and not self._out_fh.closed:
+            self._out_fh.close()
+            self._out_fh = None
         if self._temp_dir_owner and self._settings.temp_dir and osp.isdir(self._settings.temp_dir):
             shutil.rmtree(self._settings.temp_dir, ignore_errors=True)
             self._settings.temp_dir = None
             self._temp_dir_owner = False
+        if self._ramdisk_device:
+            _detach_macos_ramdisk(self._ramdisk_device)
+            self._ramdisk_device = None
 
     def push(self, name, var, timeout=None, verbose=True):
         """
@@ -980,10 +1004,22 @@ class Oct2Py:
             if not sandboxed and osp.isdir(shm) and os.access(shm, os.W_OK):
                 self._settings.temp_dir = tempfile.mkdtemp(dir=shm, prefix="oct2py_")
                 atexit.register(shutil.rmtree, self._settings.temp_dir, True)
-            else:
+            elif sys.platform == "darwin" and not sandboxed and self._settings.ramdisk_size_mb > 0:
+                device, mount = _create_macos_ramdisk(self._settings.ramdisk_size_mb)
+                if device:
+                    self._ramdisk_device = device
+                    self._settings.temp_dir = tempfile.mkdtemp(dir=mount, prefix="oct2py_")
+                    atexit.register(shutil.rmtree, self._settings.temp_dir, True)
+                    atexit.register(_detach_macos_ramdisk, device)
+            if self._settings.temp_dir is None:
                 self._settings.temp_dir = os.path.join(self._engine.tmp_dir, "oct2py")
                 os.makedirs(self._settings.temp_dir, exist_ok=True)
             self._temp_dir_owner = True
+
+        # Pre-open writer.mat so the file descriptor is reused across calls,
+        # avoiding repeated open/close syscall overhead.
+        if self._out_fh is None or self._out_fh.closed:
+            self._out_fh = open(osp.join(self._settings.temp_dir, "writer.mat"), "w+b")  # noqa: SIM115
 
         # Add local Octave scripts.
         self._engine.eval('addpath("%s");' % HERE.replace(osp.sep, "/"))
@@ -1036,7 +1072,7 @@ class Oct2Py:
 
         write_file(
             req,
-            out_file,
+            self._out_fh,
             oned_as=self._settings.oned_as,
             convert_to_float=self._settings.convert_to_float,
         )

--- a/oct2py/dynamic.py
+++ b/oct2py/dynamic.py
@@ -223,7 +223,7 @@ class OctaveUserClass:
             dtype.append((str(attr), object))
             values.append(getattr(instance, attr))
         struct = np.array([tuple(values)], dtype)
-        return MatlabObject(struct, instance._name)
+        return MatlabObject(struct, instance._name)  # type: ignore[arg-type, unused-ignore]
 
     @classmethod
     def to_pointer(cls, instance):

--- a/oct2py/dynamic.py
+++ b/oct2py/dynamic.py
@@ -223,7 +223,7 @@ class OctaveUserClass:
             dtype.append((str(attr), object))
             values.append(getattr(instance, attr))
         struct = np.array([tuple(values)], dtype)
-        return MatlabObject(struct, instance._name)  # type: ignore[arg-type]
+        return MatlabObject(struct, instance._name)
 
     @classmethod
     def to_pointer(cls, instance):

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -4,6 +4,7 @@
 
 import dis
 import inspect
+import os
 import threading
 
 import numpy as np
@@ -56,14 +57,28 @@ def read_file(path, session=None, keep_matlab_shapes=False):
     return out
 
 
-def write_file(obj, path, oned_as="row", convert_to_float=True):
-    """Save a Python object to an Octave file on the given path."""
+def write_file(obj, path_or_fh, oned_as="row", convert_to_float=True):
+    """Save a Python object to an Octave file.
+
+    ``path_or_fh`` may be a file path (str / os.PathLike) or an open
+    binary file object.  When a file object is supplied it is seeked to
+    the beginning and truncated before writing so that the same handle
+    can be reused across multiple calls.
+    """
     data = _encode(obj, convert_to_float)
     try:
-        # scipy.io.savemat is not thread-save.
+        # scipy.io.savemat is not thread-safe.
         # See https://github.com/scipy/scipy/issues/7260
         with _WRITE_LOCK:
-            savemat(path, data, appendmat=False, oned_as=oned_as, long_field_names=True)
+            if isinstance(path_or_fh, (str, os.PathLike)):
+                savemat(path_or_fh, data, appendmat=False, oned_as=oned_as, long_field_names=True)
+            else:
+                # File-like object: rewind and overwrite in place, then flush
+                # so the kernel buffer is up to date before Octave reads it.
+                path_or_fh.seek(0)
+                path_or_fh.truncate(0)
+                savemat(path_or_fh, data, appendmat=False, oned_as=oned_as, long_field_names=True)
+                path_or_fh.flush()
     except KeyError:  # pragma: no cover
         msg = "could not save mat file"
         raise Exception(msg) from None

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -348,7 +348,7 @@ def _encode(data, convert_to_float):  # noqa
     # Handle matlab objects.
     if isinstance(data, MatlabObject):
         view = data.view(np.ndarray)
-        out = MatlabObject(data, data.classname)  # type: ignore[arg-type]
+        out = MatlabObject(data, data.classname)
         for name in out.dtype.names:  # type:ignore[union-attr]
             out[name] = _encode(view[name], ctf)
         return out

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -348,7 +348,7 @@ def _encode(data, convert_to_float):  # noqa
     # Handle matlab objects.
     if isinstance(data, MatlabObject):
         view = data.view(np.ndarray)
-        out = MatlabObject(data, data.classname)
+        out = MatlabObject(data, data.classname)  # type: ignore[arg-type, unused-ignore]
         for name in out.dtype.names:  # type:ignore[union-attr]
             out[name] = _encode(view[name], ctf)
         return out

--- a/oct2py/settings.py
+++ b/oct2py/settings.py
@@ -54,6 +54,13 @@ class Oct2PySettings(BaseSettings):
         False to skip loading the user init file, which is useful in
         reproducible or sandboxed environments where the init file may
         alter the path, set conflicting options, or is simply unavailable.
+    ramdisk_size_mb : int
+        macOS only.  When set to a positive integer, oct2py will create a
+        temporary HFS+ RAM disk of the given size (in MiB) and use it as
+        the MAT-file exchange directory.  The disk is unmounted automatically
+        on session exit.  Has no effect on Linux (where ``/dev/shm`` is used
+        automatically) or on Windows.  Defaults to ``0`` (disabled).
+        Can also be set via the ``OCT2PY_RAMDISK_SIZE_MB`` environment variable.
 
     Examples
     --------
@@ -92,3 +99,4 @@ class Oct2PySettings(BaseSettings):
     plot_res: int | None = None
     extra_cli_options: str = ""
     load_octaverc: bool = True
+    ramdisk_size_mb: int = 0

--- a/oct2py/utils.py
+++ b/oct2py/utils.py
@@ -2,8 +2,11 @@
 # Copyright (c) oct2py developers.
 # Distributed under the terms of the MIT License.
 
+import contextlib
 import logging
 import os
+import subprocess
+import sys
 
 
 class Oct2PyError(Exception):
@@ -36,6 +39,47 @@ def get_log(name=None):
     """
     name = "oct2py" if name is None else "oct2py." + name
     return logging.getLogger(name)
+
+
+def _create_macos_ramdisk(size_mb: int) -> tuple[str, str] | tuple[None, None]:
+    """Create a RAM disk on macOS via hdiutil/diskutil.
+
+    Returns ``(device, mount_point)`` on success, ``(None, None)`` on failure.
+    Only meaningful on macOS; on other platforms always returns ``(None, None)``.
+    """
+    if sys.platform != "darwin":
+        return None, None
+    sectors = size_mb * 2048  # 512 bytes per sector
+    vol_name = f"oct2py_{os.getpid()}"
+    device: str | None = None
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["hdiutil", "attach", "-nomount", f"ram://{sectors}"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        device = result.stdout.strip()
+        subprocess.run(  # noqa: S603
+            ["diskutil", "erasevolume", "HFS+", vol_name, device],  # noqa: S607
+            capture_output=True,
+            check=True,
+        )
+        return device, f"/Volumes/{vol_name}"
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        if device:
+            _detach_macos_ramdisk(device)
+        return None, None
+
+
+def _detach_macos_ramdisk(device: str) -> None:
+    """Unmount and release a macOS RAM disk created by hdiutil."""
+    with contextlib.suppress(Exception):
+        subprocess.run(  # noqa: S603
+            ["hdiutil", "detach", "-quiet", device],  # noqa: S607
+            capture_output=True,
+            check=False,
+        )
 
 
 def _augment_path_for_windows(executable: str) -> None:

--- a/oct2py/utils.py
+++ b/oct2py/utils.py
@@ -49,7 +49,7 @@ def _create_macos_ramdisk(size_mb: int) -> tuple[str, str] | tuple[None, None]:
     """
     if sys.platform != "darwin":
         return None, None
-    sectors = size_mb * 2048  # 512 bytes per sector
+    sectors = size_mb * 2048  # type: ignore[unreachable, unused-ignore]  # 512 bytes per sector
     vol_name = f"oct2py_{os.getpid()}"
     device: str | None = None
     try:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -901,3 +901,157 @@ def test_system_cat_works_via_oct2py():
     """Oct2Py session can call system('cat --version') without raising."""
     with Oct2Py() as oc:
         oc.eval("[~, out] = system('cat --version');", nout=0)
+
+
+# ---------------------------------------------------------------------------
+# Tests for writer.mat file-handle reuse (phase 2 of issue #322)
+# ---------------------------------------------------------------------------
+
+
+class TestWriterFileHandle:
+    def test_out_fh_open_after_init(self):
+        """_out_fh is a valid open binary file after session start."""
+        with Oct2Py() as oc:
+            assert oc._out_fh is not None
+            assert not oc._out_fh.closed
+
+    def test_out_fh_stable_across_calls(self):
+        """The same file handle object is reused for every feval call."""
+        with Oct2Py() as oc:
+            fh_id = id(oc._out_fh)
+            oc.eval("1 + 1", nout=0)
+            oc.eval("2 + 2", nout=0)
+            assert id(oc._out_fh) == fh_id
+
+    def test_out_fh_closed_on_exit(self):
+        """_out_fh is closed and set to None when the session exits."""
+        oc = Oct2Py()
+        fh = oc._out_fh
+        oc.exit()
+        assert fh.closed
+        assert oc._out_fh is None
+
+
+def test_write_file_accepts_file_handle(tmp_path):
+    """write_file writes a valid MAT file when given an open file handle."""
+    from oct2py.io import read_file, write_file
+
+    mat_path = tmp_path / "test.mat"
+    with open(mat_path, "w+b") as fh:
+        write_file({"x": np.array([1.0, 2.0])}, fh)
+
+    result = read_file(str(mat_path))
+    assert result["x"].ravel().tolist() == [1.0, 2.0]
+
+
+def test_write_file_handle_overwrites_on_second_call(tmp_path):
+    """A second write_file call on the same handle overwrites the first."""
+    from oct2py.io import read_file, write_file
+
+    mat_path = tmp_path / "test.mat"
+    with open(mat_path, "w+b") as fh:
+        write_file({"x": np.array([1.0, 2.0])}, fh)
+        write_file({"x": np.array([99.0, 100.0])}, fh)
+
+    result = read_file(str(mat_path))
+    assert result["x"].ravel().tolist() == [99.0, 100.0]
+
+
+# ---------------------------------------------------------------------------
+# Tests for macOS RAM disk helpers and ramdisk_size_mb (issue #322)
+# ---------------------------------------------------------------------------
+
+from oct2py.utils import _create_macos_ramdisk, _detach_macos_ramdisk  # noqa: E402
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
+class TestMacOSRamdisk:
+    def test_create_returns_none_on_subprocess_failure(self, monkeypatch):
+        """Returns (None, None) when hdiutil is unavailable or fails."""
+        import subprocess as sp
+
+        def _fail(*a, **kw):
+            raise FileNotFoundError("hdiutil not found")
+
+        monkeypatch.setattr(sp, "run", _fail)
+        device, mount = _create_macos_ramdisk(32)
+        assert device is None
+        assert mount is None
+
+    def test_detach_swallows_errors(self):
+        """_detach_macos_ramdisk does not raise for an invalid device path."""
+        _detach_macos_ramdisk("/dev/nonexistent_disk999")
+
+    def test_oct2py_ramdisk_sets_temp_dir(self, tmp_path, monkeypatch):
+        """Oct2Py(ramdisk_size_mb=N) uses the RAM disk mount as temp_dir."""
+        import oct2py.core as core_mod
+
+        monkeypatch.setattr(
+            core_mod, "_create_macos_ramdisk", lambda n: ("fake_dev", str(tmp_path))
+        )
+        detached: list[str] = []
+
+        def _record_detach(d):
+            detached.append(d)
+
+        monkeypatch.setattr(core_mod, "_detach_macos_ramdisk", _record_detach)
+
+        with Oct2Py(ramdisk_size_mb=64) as oc:
+            assert oc._settings.temp_dir.startswith(str(tmp_path))
+            assert oc._ramdisk_device == "fake_dev"
+            assert oc.eval("2 + 2", nout=1) == 4.0
+
+        assert "fake_dev" in detached
+
+    def test_oct2py_falls_back_when_ramdisk_fails(self, monkeypatch):
+        """Falls back to the default temp_dir when RAM disk creation fails."""
+        import oct2py.core as core_mod
+
+        monkeypatch.setattr(core_mod, "_create_macos_ramdisk", lambda n: (None, None))
+
+        with Oct2Py(ramdisk_size_mb=64) as oc:
+            assert oc._ramdisk_device is None
+            assert oc.eval("1 + 1", nout=1) == 2.0
+
+    def test_partial_failure_detaches_device(self, monkeypatch):
+        """If hdiutil succeeds but diskutil fails, the allocated device is detached."""
+        import subprocess as sp
+
+        call_count = 0
+        detached: list[str] = []
+
+        def _selective_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call (hdiutil attach): succeed, return a fake device path.
+                result = sp.CompletedProcess(args[0], 0)
+                result.stdout = "/dev/fake_disk9"
+                result.stderr = ""
+                return result
+            # Second call (diskutil erasevolume): fail.
+            raise sp.CalledProcessError(1, args[0])
+
+        def _record_detach(d):
+            detached.append(d)
+
+        monkeypatch.setattr(sp, "run", _selective_fail)
+        monkeypatch.setattr("oct2py.utils._detach_macos_ramdisk", _record_detach)
+
+        device, mount = _create_macos_ramdisk(32)
+
+        assert device is None
+        assert mount is None
+        assert "/dev/fake_disk9" in detached
+
+    def test_create_and_detach_roundtrip(self):
+        """_create_macos_ramdisk mounts a usable directory; _detach cleans up."""
+        device, mount = _create_macos_ramdisk(32)
+        try:
+            assert device is not None
+            assert mount is not None
+            assert os.path.isdir(mount)
+        finally:
+            if device:
+                _detach_macos_ramdisk(device)
+        assert not os.path.isdir(mount)


### PR DESCRIPTION
## References

Closes #322

## Description

Reduces per-call MAT-file I/O overhead on macOS and all platforms via
two independent improvements.

## Changes

**Opt-in macOS RAM disk (`ramdisk_size_mb`)**

- New `ramdisk_size_mb` parameter on `Oct2Py` and `Oct2PySettings`
  (also readable from `OCT2PY_RAMDISK_SIZE_MB`). When set to a positive
  integer on macOS, oct2py creates a temporary HFS+ RAM disk via
  `hdiutil`/`diskutil` and uses it as the MAT-file exchange directory.
  The disk is unmounted automatically on `exit()` or process shutdown.
- Falls back silently to the default `temp_dir` if disk creation fails.
- Has no effect on Linux (where `/dev/shm` is used automatically) or
  Windows.
- Bug fix: if `hdiutil attach` succeeds but `diskutil erasevolume`
  fails, the allocated device is now detached before returning
  `(None, None)` to avoid leaking a RAM disk device.
- Helper functions `_create_macos_ramdisk` / `_detach_macos_ramdisk`
  live in `utils.py`.

**Reuse `writer.mat` file handle (phase 2)**

- `Oct2Py` now pre-opens `writer.mat` once per session as `_out_fh`
  and reuses the handle across all `_feval` calls, avoiding repeated
  `open`/`close` syscall overhead.
- `write_file()` accepts either a path (`str` / `os.PathLike`) or an
  open binary file object; the file-object path seeks to 0, truncates,
  writes, and flushes so the kernel buffer is visible to Octave.

**CI / coverage**

- Moved macOS from `test-other` into the `cover` job (same limited
  test-file arguments as Windows).
- Updated `codecov.yml` `after_n_builds` from 2 → 3 to wait for the
  new macOS upload.

**Docs**

- Added a "Reducing MAT-file overhead with a RAM-backed temp directory"
  subsection under Speed in `docs/info.md`, covering Linux (automatic),
  macOS opt-in RAM disk, and macOS user-managed RAM disk via `temp_dir`.

## Backwards-incompatible changes

None

## Testing

- 11 new tests added to `tests/test_misc.py`.
- `TestWriterFileHandle` (3 tests, all platforms): verifies `_out_fh`
  is open after init, stable across calls, and closed on `exit()`.
- `test_write_file_accepts_file_handle` /
  `test_write_file_handle_overwrites_on_second_call` (standalone, all
  platforms): unit tests for `write_file` with a file-like object.
- `TestMacOSRamdisk` (6 tests, `skipif sys.platform != "darwin"`):
  subprocess failure returns `(None, None)`; detach swallows errors;
  partial failure (hdiutil OK, diskutil fails) detaches the allocated
  device; `ramdisk_size_mb` integration with mocked helpers; fallback
  on creation failure; full hdiutil round-trip.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code