### PR TITLE
Add validate-pyproject pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,11 @@ repos:
       - id: codespell
         args: ["-L", "ans,te,manuel"]
 
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
+
   - repo: https://github.com/scientific-python/cookie
     rev: "2025.11.21"
     hooks:

--- a/justfile
+++ b/justfile
@@ -21,6 +21,7 @@ lint:
     just pre-commit ruff-check
     just pre-commit interrogate
     just pre-commit doc8
+    just pre-commit validate-pyproject
 
 # Run type checking (mypy)
 typing:


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Adds the `validate-pyproject` pre-commit hook to validate `pyproject.toml` against the PEP 517/518/621 schemas on every commit.

## Changes

- Added `validate-pyproject` (v0.25) repo to `.pre-commit-config.yaml`
- Added `just pre-commit validate-pyproject` step to the `lint` recipe in `Justfile`

## Backwards-incompatible changes

None

## Testing

Ran `just lint` — all hooks pass including the new `validate-pyproject` hook.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code