### PR TITLE
Fix CI workflows and add nightly test runs

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -5,16 +5,18 @@ on:
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 9am
 
-permissions:
-  pull-requests: write
-
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -23,6 +25,7 @@ jobs:
       - run: pre-commit autoupdate
       - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: pre-commit autoupdate'
           title: 'chore: pre-commit autoupdate'
           branch: pre-commit-autoupdate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Run weekly
+    # Run nightly
     # * is a special character in YAML so you have to quote this string
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
 
 permissions:
   contents: read
@@ -147,6 +147,23 @@ jobs:
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - run: just typing
 
+  test_release:
+    name: Test Release (Dry Run)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: calysto/maintainer_tools/actions/base-setup@v1
+      - uses: calysto/maintainer_tools/actions/release@v1
+        with:
+          version: patch
+          dry_run: "true"
+          ref: ${{ github.head_ref }}
+
   tests_check: # This job does nothing and is only used for the branch protection
     if: always()
     needs:
@@ -157,10 +174,12 @@ jobs:
       - typing
       - docs
       - benchmark
+      - test_release
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           allowed-failures: benchmark
+          allowed-skips: test_release
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## References

N/A

## Description

Fix the pre-commit autoupdate workflow push permission error and improve CI scheduling.

## Changes

- **pre-commit-autoupdate.yml**: Use GitHub App token (`APP_ID`/`APP_PRIVATE_KEY`) instead of default `GITHUB_TOKEN` to fix 403 permission error when pushing the PR branch
- **tests.yml**: Switch test schedule from weekly to nightly
- **tests.yml**: Add `test_release` dry-run job that runs on PRs to validate the release process
- **tests.yml**: Add `test_release` to `tests_check` with `allowed-skips` so it doesn't block non-PR events

## Backwards-incompatible changes

None

## Testing

CI will validate the changes.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Opus 4.6 via Claude Code