### PR TITLE
Fix dry_run handling in nightly release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: ${{ inputs.dry_run }}
-          verbose: ${{ inputs.dry_run }}
+          skip-existing: ${{ github.event_name == 'schedule' || inputs.dry_run }}
+          verbose: ${{ github.event_name == 'schedule' || inputs.dry_run }}
 
       - name: Upload package to PyPI
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !(github.event_name == 'schedule' || inputs.dry_run) }}
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -4424,4 +4424,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "c25cefdf95637f2d1790cb61c7be0c45c8a00d6b57f512ccf4cf06f0ab28c34a"
+content-hash = "e762cc24873ccf9753e0c0010a20977552668a0f4d872b684a4188c621e91fc6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ docs = [
     "mkdocs>=1.5",
     "mkdocs-material>=9.0",
     "mkdocstrings[python]>=0.24",
-    "mkdocs-jupyter>=0.25",
+    "mkdocs-jupyter>=0.25,!=0.26.0",
 ]
 bench = [
     "asv",


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

When the release workflow is triggered on a schedule (nightly), `inputs.dry_run` is undefined. The `publish` job was using `inputs.dry_run` directly for `skip-existing`, `verbose`, and the PyPI upload condition — meaning nightly dry runs would attempt a real PyPI upload.

The `release` job already handled this correctly with a ternary expression. This PR applies the same fix to the `publish` job.

## Changes

- Replace `inputs.dry_run` with `github.event_name == 'schedule' || inputs.dry_run` in the `publish` job's `skip-existing`, `verbose`, and upload condition

## Backwards-incompatible changes

None

## Testing

Reproducer: https://github.com/blink1073/oct2py/actions/runs/23482113796

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code