### PR TITLE
Add changelog_body input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      changelog_body:
+        description: "Custom release notes (overrides auto-generated changelog). Use \\n for newlines, or trigger via 'gh workflow run' for real multiline input."
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "0 9 * * *"
 
@@ -34,6 +39,7 @@ jobs:
         with:
           version: ${{ github.event_name == 'schedule' && '10.10.10.10' || inputs.version }}
           dry_run: ${{ github.event_name == 'schedule' && 'true' || inputs.dry_run }}
+          changelog_body: ${{ inputs.changelog_body }}
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           ref: ${{ github.ref_name }}


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Adds a `changelog_body` input to the `workflow_dispatch` trigger of the release workflow, allowing callers to supply custom release notes that override the auto-generated changelog.

## Changes

- Added `changelog_body` input to `workflow_dispatch` inputs with description, type, and default
- Passed `changelog_body` through to the `calysto/maintainer_tools/actions/release@v1` action

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code