### PR TITLE
Autofill test matrix from build-and-inspect-python-package classifiers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ concurrency:
 
 jobs:
   test:
-    needs: docs
+    needs: build
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ${{ fromJSON(needs.build.outputs.supported_python_classifiers_json_array) }}
       fail-fast: false
 
     steps:
@@ -164,20 +164,25 @@ jobs:
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - run: just typing
 
-  make_sdist:
+  build:
     name: Build and Inspect Package
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      supported_python_classifiers_json_array: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
-      - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
+      - uses: hynek/build-and-inspect-python-package@35116b25fb28e4b91149d761b2230d28ef49adc0 # v2.16.0
+        id: baipp
+        with:
+          include-free-threaded: "true"
 
   test_sdist:
     name: Test SDist
-    needs: make_sdist
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -220,7 +225,7 @@ jobs:
       - typing
       - docs
       - benchmark
-      - make_sdist
+      - build
       - test_sdist
       - test_release
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development",
 ]


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Uses the `supported_python_classifiers_json_array` output from `hynek/build-and-inspect-python-package` v2.16.0 to automatically drive the test matrix, so the supported Python versions stay in sync with the trove classifiers declared in `pyproject.toml`.

## Changes

- Rename `make_sdist` job → `build`; make `test` depend on `build`
- Upgrade `hynek/build-and-inspect-python-package` to v2.16.0 with `include-free-threaded: "true"`
- Use `supported_python_classifiers_json_array` output to populate the `test` job matrix
- Add `Programming Language :: Python :: 3.11–3.14` and `Programming Language :: Python :: Free Threading` trove classifiers to `pyproject.toml`

## Backwards-incompatible changes

None

## Testing

CI matrix is now driven from classifiers; adding/removing a version classifier automatically updates the test matrix.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 via Claude Code