### PR TITLE
Fix PermissionError on Windows at interpreter exit (writer.mat held open)

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -285,8 +285,21 @@ class Oct2Py:
         except Exception:  # noqa: S110  # pragma: no cover
             pass
 
+    def _close_writer(self) -> None:
+        """Close the persistent writer.mat file handle.
+
+        Registered with atexit so it runs before shutil.rmtree fires at
+        interpreter exit.  On Windows, open files cannot be deleted, so the
+        handle must be released before the temp directory is removed
+        (PermissionError: [WinError 32]).
+        """
+        if self._out_fh and not self._out_fh.closed:
+            self._out_fh.close()
+            self._out_fh = None
+
     def exit(self):
         """Quits this octave session and cleans up."""
+        atexit.unregister(self._close_writer)
         if self._engine:
             if callable(atexit.unregister):
                 atexit.unregister(self._engine._cleanup)
@@ -1033,6 +1046,13 @@ class Oct2Py:
         # avoiding repeated open/close syscall overhead.
         if self._out_fh is None or self._out_fh.closed:  # type: ignore[unreachable]
             self._out_fh = open(osp.join(self._settings.temp_dir, "writer.mat"), "w+b")  # noqa: SIM115
+        # Ensure the handle is closed before shutil.rmtree fires at interpreter
+        # exit.  On Windows, open files cannot be deleted (PermissionError:
+        # [WinError 32]).  atexit is LIFO, so registering here (after the
+        # engine's rmtree registration) guarantees _close_writer runs first.
+        # unregister first to avoid duplicate entries on restart.
+        atexit.unregister(self._close_writer)
+        atexit.register(self._close_writer)
 
         # Add local Octave scripts.
         self._engine.eval('addpath("%s");' % HERE.replace(osp.sep, "/"))

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -285,27 +285,15 @@ class Oct2Py:
         except Exception:  # noqa: S110  # pragma: no cover
             pass
 
-    def _close_writer(self) -> None:
-        """Close the persistent writer.mat file handle.
-
-        Registered with atexit so it runs before shutil.rmtree fires at
-        interpreter exit.  On Windows, open files cannot be deleted, so the
-        handle must be released before the temp directory is removed
-        (PermissionError: [WinError 32]).
-        """
-        if self._out_fh and not self._out_fh.closed:
-            self._out_fh.close()
-            self._out_fh = None
-
     def exit(self):
         """Quits this octave session and cleans up."""
-        atexit.unregister(self._close_writer)
         if self._engine:
             if callable(atexit.unregister):
                 atexit.unregister(self._engine._cleanup)
             self._engine.repl.terminate()
         self._engine = None
         if self._out_fh and not self._out_fh.closed:
+            atexit.unregister(self._out_fh.close)
             self._out_fh.close()
             self._out_fh = None
         if self._temp_dir_owner and self._settings.temp_dir and osp.isdir(self._settings.temp_dir):
@@ -951,6 +939,7 @@ class Oct2Py:
         # Close any open writer file handle — its path is tied to the old
         # temp_dir and will be invalid after we create a new one below.
         if self._out_fh and not self._out_fh.closed:
+            atexit.unregister(self._out_fh.close)
             self._out_fh.close()
         self._out_fh = None
 
@@ -1049,10 +1038,11 @@ class Oct2Py:
         # Ensure the handle is closed before shutil.rmtree fires at interpreter
         # exit.  On Windows, open files cannot be deleted (PermissionError:
         # [WinError 32]).  atexit is LIFO, so registering here (after the
-        # engine's rmtree registration) guarantees _close_writer runs first.
-        # unregister first to avoid duplicate entries on restart.
-        atexit.unregister(self._close_writer)
-        atexit.register(self._close_writer)
+        # engine's rmtree registration) guarantees _out_fh.close runs first.
+        # Register the file handle's .close method directly — unlike a bound
+        # Oct2Py method, it does not hold a strong reference back to self, so
+        # __del__ can still fire normally when the session goes out of scope.
+        atexit.register(self._out_fh.close)
 
         # Add local Octave scripts.
         self._engine.eval('addpath("%s");' % HERE.replace(osp.sep, "/"))


### PR DESCRIPTION
## References

Fixes #420

## Description

On Windows, Python's `atexit` handlers fire in LIFO order at interpreter exit.
`OctaveEngine.__init__` registers `shutil.rmtree(engine.tmp_dir)` early, so it
runs *after* any handler registered later. The persistent `_out_fh` file handle
(pointing to `writer.mat` inside that temp dir) was never closed before `rmtree`
fired, causing:

```
PermissionError: [WinError 32] The process cannot access the file because it is
being used by another process: '...\\tmp1vz97ck2\\oct2py\\writer.mat'
```

On Linux/macOS unlinking an open file works fine, so this was Windows-only.

## Changes

- In `_start()`, register `self._out_fh.close` with `atexit` after the engine's `rmtree` registration — LIFO guarantees it runs first, releasing the handle before the directory is deleted.
- The file handle's `.close` method is registered directly rather than a bound `Oct2Py` method. A bound method would hold a strong reference back to `self`, preventing `__del__` from firing when the session goes out of scope and causing Octave subprocesses to accumulate (`test_threadpool_no_process_leak`).
- `atexit.unregister(self._out_fh.close)` is called before closing the handle in `exit()` and on restart, to avoid stale entries in the atexit list.

## Backwards-incompatible changes

None

## Testing

Cannot reproduce locally (macOS), but the fix is mechanical: close the fd before `rmtree` using the LIFO property of `atexit`. The existing test suite passes, including `test_threadpool_no_process_leak`.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (claude-sonnet-4-6)