### PR TITLE
Fix PackageNotFoundError when imported in PyInstaller bundle

### DIFF
--- a/oct2py/_version.py
+++ b/oct2py/_version.py
@@ -2,11 +2,15 @@
 
 import re
 from collections import namedtuple
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version_metadata
 
 VersionInfo = namedtuple("VersionInfo", ["major", "minor", "micro", "releaselevel", "serial"])
 
-__version__ = _version_metadata("oct2py")
+try:
+    __version__ = _version_metadata("oct2py")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 # Build up version_info tuple for backwards compatibility
 pattern = r"(?P<major>\d+).(?P<minor>\d+).(?P<micro>\d+)(?P<releaselevel>.*?)(?P<serial>\d*)"


### PR DESCRIPTION
## References

Closes #423

## Description

When oct2py is bundled with PyInstaller, the `.dist-info` metadata directory is not included, causing `importlib.metadata.version("oct2py")` to raise `PackageNotFoundError` at import time and crash the application.

## Changes

- Wrap `importlib.metadata.version("oct2py")` in `try/except PackageNotFoundError` in `_version.py`, falling back to `"0.0.0"` when metadata is unavailable

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude (claude-sonnet-4-6)