### PR TITLE
Use maintainer_tools v1.3.0 actions for pre-commit, zizmor, and codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL Advanced"
 
 on:
@@ -22,23 +11,12 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
-      # required for all workflows
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
       packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
-
     strategy:
       fail-fast: false
       matrix:
@@ -47,55 +25,12 @@ jobs:
           build-mode: none
         - language: python
           build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
       with:
-        languages: ${{ matrix.language }}
+        persist-credentials: false
+    - uses: calysto/maintainer_tools/actions/codeql@v1.3.0
+      with:
+        language: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
-      with:
-        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: calysto/maintainer_tools/actions/codeql@v1.3.0
+    - uses: calysto/maintainer_tools/actions/codeql@v1
       with:
         language: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: calysto/maintainer_tools/actions/pre-commit-autoupdate@v1.3.0
+      - uses: calysto/maintainer_tools/actions/pre-commit-autoupdate@v1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -11,24 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
-      - uses: actions/setup-python@v5
+          persist-credentials: false
+      - uses: calysto/maintainer_tools/actions/pre-commit-autoupdate@v1.3.0
         with:
-          python-version: '3.x'
-          cache: pip
-      - run: pip install pre-commit
-      - run: pre-commit autoupdate
-      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          commit-message: 'chore: pre-commit autoupdate'
-          title: 'chore: pre-commit autoupdate'
-          branch: pre-commit-autoupdate
-          labels: maintenance
+          app-id: ${{ vars.APP_ID }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: calysto/maintainer_tools/actions/pre-commit-run@v1.3.0
+      - uses: calysto/maintainer_tools/actions/pre-commit-run@v1
 
   typing:
     name: Typing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,11 +150,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: calysto/maintainer_tools/actions/base-setup@v1
-      - run: just pre-commit --hook-stage=manual
-      - name: Show diff on failure
-        if: failure()
-        run: git diff
+        with:
+          persist-credentials: false
+      - uses: calysto/maintainer_tools/actions/pre-commit-run@v1.3.0
 
   typing:
     name: Typing

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,14 +8,13 @@ on:
 
 jobs:
   zizmor:
-    name: zizmor latest via Cargo
+    name: zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+      - uses: calysto/maintainer_tools/actions/zizmor@v1.3.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: calysto/maintainer_tools/actions/zizmor@v1.3.0
+      - uses: calysto/maintainer_tools/actions/zizmor@v1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        actions/*: ref-pin
-        calysto/maintainer_tools/*: ref-pin


### PR DESCRIPTION
## Summary

- Replace local `zizmor.yml` config and workflow with `calysto/maintainer_tools/actions/zizmor@v1.3.0` (bundled config used as fallback)
- Replace verbose `codeql.yml` workflow with `calysto/maintainer_tools/actions/codeql@v1.3.0`
- Replace `pre-commit-autoupdate.yml` workflow (manual prek + `peter-evans/create-pull-request`) with `calysto/maintainer_tools/actions/pre-commit-autoupdate@v1.3.0`
- Replace `base-setup` + `just pre-commit` in the `pre_commit` job in `tests.yml` with `calysto/maintainer_tools/actions/pre-commit-run@v1.3.0`