### PR TITLE
ci: fix octave install on macos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@64a3888bac86006cba0aafb6fa9c8bf04abaaf8e # v1.0.0
+        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Install signal package
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@64a3888bac86006cba0aafb6fa9c8bf04abaaf8e # v1.0.0
+        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
         with:
           install-type: ${{ matrix.install-type }}
       - name: Run tests
@@ -108,7 +108,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@64a3888bac86006cba0aafb6fa9c8bf04abaaf8e # v1.0.0
+        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -130,7 +130,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@64a3888bac86006cba0aafb6fa9c8bf04abaaf8e # v1.0.0
+        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -188,7 +188,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@64a3888bac86006cba0aafb6fa9c8bf04abaaf8e # v1.0.0
+        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -210,7 +210,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@64a3888bac86006cba0aafb6fa9c8bf04abaaf8e # v1.0.0
+        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Run PyInstaller test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Octave
-        uses: calysto/octave_kernel@64a3888bac86006cba0aafb6fa9c8bf04abaaf8e # v1.0.0
+        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
         with:
           install-type: "ubuntu"
       - name: Install signal package


### PR DESCRIPTION
Bump version of `octave_kernel` action used in CI.