### PR TITLE
Update macOS version in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
       fail-fast: false
 
     steps:
@@ -200,7 +200,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## References

Fixes CI failure in job #1199 (`cover (macos-latest)`) — `brew install octave` aborts with exit code 134 after `macos-latest` migrated to macOS 26 on June 15, 2026.

## Description

Pin the macOS CI runner from `macos-latest` to `macos-15` to avoid breakage caused by the `macos-latest` label migrating to macOS 26. Octave installation via Homebrew is not yet compatible with macOS 26, causing the install step to abort (exit code 134). This is a temporary workaround until upstream Homebrew/Octave support for macOS 26 is available.

## Changes

- Changed `runs-on: macos-latest` to `runs-on: macos-15` in the CI workflow

## Backwards-incompatible changes

None

## Testing

CI job should pass on the pinned macOS 15 runner.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used:** Claude (Anthropic)