### PR TITLE
CI: Use version pins instead of shas for first party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,14 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "calysto/maintainer_tools"
+      - dependency-name: "calysto/octave_kernel"
     groups:
       actions:
         patterns:
           - "*"
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_kernel@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -59,7 +59,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_kernel@v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Install signal package
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_kernel@v1
         with:
           install-type: ${{ matrix.install-type }}
       - name: Run tests
@@ -108,7 +108,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_kernel@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -130,7 +130,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_kernel@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -188,7 +188,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_kernel@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -210,7 +210,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_kernel@v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Run PyInstaller test

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        calysto/maintainer_tools/*: ref-pin
+        calysto/octave_kernel/*: ref-pin


### PR DESCRIPTION
## References

N/A

## Description

Replaces pinned SHA references for the first-party `calysto/octave_kernel` action with a version tag pin (`@v1`), and adds `calysto/maintainer_tools` and `calysto/octave_kernel` to the Dependabot ignore list so these first-party actions are no longer flagged for SHA-pin updates.

## Changes

- `.github/workflows/tests.yml`: Replaced all `calysto/octave_kernel@<sha> # v1.0.4` references with `calysto/octave_kernel@v1` across the workflow's job steps.
- `.github/dependabot.yml`: Added `calysto/maintainer_tools` and `calysto/octave_kernel` to the `ignore` list for the GitHub Actions dependency group, and grouped Actions updates under a single `actions` group.

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [ ] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: None