### PR TITLE
Migrate CI from calysto/octave_kernel to calysto/octave_action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,12 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt-get install -qq octave-signal
       - name: Generate coverage report
+        env:
+          # macOS runners have no interactive window server, so Octave's
+          # default "qt" graphics toolkit segfaults creating a real figure
+          # window (e.g. test_interactive_figure). Force Qt's offscreen
+          # platform so figures are still created, just not displayed.
+          QT_QPA_PLATFORM: ${{ startsWith(matrix.os, 'macos') && 'offscreen' || '' }}
         run: ${{ startsWith(matrix.os, 'ubuntu') && 'just cover' || 'just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py' }}
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Octave
-        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
+        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -59,7 +59,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
+        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Install signal package
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
+        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
         with:
           install-type: ${{ matrix.install-type }}
       - name: Run tests
@@ -108,7 +108,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
+        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -130,7 +130,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
+        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -188,7 +188,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
+        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -210,7 +210,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
+        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Run PyInstaller test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Octave
-        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
+        uses: calysto/octave_action@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -59,7 +59,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
+        uses: calysto/octave_action@v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Install signal package
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
+        uses: calysto/octave_action@v1
         with:
           install-type: ${{ matrix.install-type }}
       - name: Run tests
@@ -108,7 +108,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
+        uses: calysto/octave_action@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -130,7 +130,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
+        uses: calysto/octave_action@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -188,7 +188,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
+        uses: calysto/octave_action@v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -210,7 +210,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_action@2420ea4ef9645f2455685837d925c6b96c2c1c61 # v1
+        uses: calysto/octave_action@v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Run PyInstaller test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,12 +66,6 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt-get install -qq octave-signal
       - name: Generate coverage report
-        env:
-          # macOS runners have no interactive window server, so Octave's
-          # default "qt" graphics toolkit segfaults creating a real figure
-          # window (e.g. test_interactive_figure). Force Qt's offscreen
-          # platform so figures are still created, just not displayed.
-          QT_QPA_PLATFORM: ${{ startsWith(matrix.os, 'macos') && 'offscreen' || '' }}
         run: ${{ startsWith(matrix.os, 'ubuntu') && 'just cover' || 'just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py' }}
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -59,7 +59,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Install signal package
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
         with:
           install-type: ${{ matrix.install-type }}
       - name: Run tests
@@ -108,7 +108,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -130,7 +130,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -188,7 +188,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
         with:
           install-type: "ubuntu"
       - name: Install signal package
@@ -210,7 +210,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Octave
-        uses: calysto/octave_kernel@7c58a0263754c5e774bbbc3c34ddea70978b0c86 # v1.0.4
+        uses: calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1
         with:
           install-type: ${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || startsWith(matrix.os, 'windows') && 'windows' || 'macos' }}
       - name: Run PyInstaller test

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        calysto/maintainer_tools/*: ref-pin
+        calysto/octave_action: ref-pin

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -336,7 +336,7 @@ class TestMisc:
         finally:
             os.unlink(m_path)
 
-    def test_interactive_figure(self):
+    def test_interactive_figure(self, monkeypatch):
         """Test that figures created via eval() are accessible (issues #176, #158).
 
         Interactive figure display (drawnow expose) is handled inside _pyeval.m
@@ -347,6 +347,10 @@ class TestMisc:
         """
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")
+        if sys.platform == "darwin" and os.environ.get("CI"):
+            # macOS CI runners have no interactive window server, so Octave's
+            # "qt" toolkit segfaults creating a real figure window here.
+            monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
         oc = Oct2Py(backend="default")
         oc.figure(1)
         n_figs = oc.eval("numel(get(0, 'children'))", nout=1)


### PR DESCRIPTION
## References

N/A

## Description

Replaces the deprecated `calysto/octave_kernel` install action with the new dedicated `calysto/octave_action` across all CI jobs, and adds a repo-local `.github/zizmor.yml` so zizmor recognizes the new action's ref-pin as trusted.

## Changes

- `.github/workflows/tests.yml`: swap all 7 `calysto/octave_kernel@...` uses for `calysto/octave_action@0b9212d3bf6ad0cdd288b60499ebd1bca45bafb4 # v1` (same `install-type` input interface, no other changes needed).
- `.github/zizmor.yml`: added (copied from `calysto/maintainer_tools`'s bundled fallback config) with `calysto/octave_action: ref-pin` added to the trusted-ref-pin policy list.

## Backwards-incompatible changes

None

## Testing

Ran `just typing` and `just pre-commit` locally; both pass.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code