### PR TITLE
Tolerate flaky pexpect teardown race on free-threaded Python

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -20,6 +20,7 @@ import weakref
 import numpy as np
 from metakernel.pexpect import EOF, TIMEOUT
 from octave_kernel.kernel import STDIN_PROMPT, OctaveEngine
+from pexpect.exceptions import ExceptionPexpect
 
 from .dynamic import (
     OctaveNamespaceProxy,
@@ -285,12 +286,32 @@ class Oct2Py:
         except Exception:  # noqa: S110  # pragma: no cover
             pass
 
+    def _terminate_repl(self):
+        """Terminate the REPL's child process, tolerating a stale-alive race.
+
+        ptyprocess's close() sleeps `delayafterclose` (default 0.1s) then
+        checks isalive() before raising ExceptionPexpect; under the
+        free-threaded (no-GIL) build, process reaping can be slow enough that
+        isalive() still reports True right after the kill signal was sent.
+        The signal has already been delivered by the time this fires, so
+        treat it as a non-fatal cleanup race rather than a real failure to
+        terminate.
+        """
+        assert self._engine is not None  # noqa: S101
+        try:
+            self._engine.repl.terminate()
+        except ExceptionPexpect:
+            self.logger.debug(
+                "Octave child process did not confirm termination promptly; "
+                "continuing (signal was already sent)."
+            )
+
     def exit(self):
         """Quits this octave session and cleans up."""
         if self._engine:
             if callable(atexit.unregister):
                 atexit.unregister(self._engine._cleanup)
-            self._engine.repl.terminate()
+            self._terminate_repl()
         self._engine = None
         if self._out_fh and not self._out_fh.closed:
             atexit.unregister(self._out_fh.close)
@@ -934,7 +955,7 @@ class Oct2Py:
     def restart(self):  # noqa: PLR0912, PLR0915
         """Restart an Octave session in a clean state"""
         if self._engine:
-            self._engine.repl.terminate()
+            self._terminate_repl()
 
         # Close any open writer file handle — its path is tied to the old
         # temp_dir and will be invalid after we create a new one below.
@@ -995,6 +1016,16 @@ class Oct2Py:
                 cli_options=self._settings.extra_cli_options,
                 load_octaverc=self._settings.load_octaverc,
             )
+
+            # pexpect/ptyprocess' default delayafterclose (0.1s) is too tight
+            # on some runtimes -- observed flaky on the free-threaded Python
+            # 3.14t build, where isalive() can report a stale "still running"
+            # status right after the termination signal was sent. Give it
+            # more headroom.
+            _child = getattr(self._engine.repl, "child", None)
+            if _child is not None:
+                _child.delayafterclose = 0.5
+                _child.delayafterterminate = 0.5
         except Exception as e:
             raise Oct2PyError(str(e)) from None
         finally:

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -275,6 +275,43 @@ class TestEnterDel:
         oc.__del__()  # should not raise
 
 
+class TestTerminateRepl:
+    """Tests for the ExceptionPexpect-tolerant termination helper."""
+
+    def test_exit_swallows_stale_alive_race(self):
+        """exit() should not raise when terminate() reports a stale-alive race."""
+        from pexpect.exceptions import ExceptionPexpect
+
+        oc = Oct2Py()
+        oc._engine.repl.terminate = MagicMock(
+            side_effect=ExceptionPexpect("Could not terminate the child.")
+        )
+        oc.exit()  # should not raise
+        assert oc._engine is None
+
+    def test_restart_swallows_stale_alive_race(self):
+        """restart() should tolerate the old engine's terminate() raising the same race."""
+        from pexpect.exceptions import ExceptionPexpect
+
+        oc = Oct2Py()
+        old_engine = oc._engine
+        old_engine.repl.terminate = MagicMock(
+            side_effect=ExceptionPexpect("Could not terminate the child.")
+        )
+        oc.restart()  # should not raise
+        assert oc._engine is not old_engine
+        oc.exit()
+
+    def test_terminate_repl_reraises_other_exceptions(self):
+        """Exceptions other than ExceptionPexpect should still propagate."""
+        oc = Oct2Py()
+        oc._engine.repl.terminate = MagicMock(side_effect=RuntimeError("boom"))
+        with pytest.raises(RuntimeError, match="boom"):
+            oc._terminate_repl()
+        oc._engine.repl.terminate = MagicMock()  # avoid raising again during exit()
+        oc.exit()
+
+
 class TestGetPointer:
     """Tests for all branches of Oct2Py.get_pointer."""
 
@@ -425,6 +462,24 @@ class TestRestart:
             pytest.raises(Oct2PyError, match="bad engine"),
         ):
             oc.restart()
+
+    def test_restart_widens_pexpect_delays(self):
+        """restart() should widen the child's delayafterclose/delayafterterminate."""
+        oc = Oct2Py()
+        child = oc._engine.repl.child
+        assert child.delayafterclose == 0.5
+        assert child.delayafterterminate == 0.5
+        oc.exit()
+
+    def test_restart_widens_pexpect_delays_skipped_without_child(self):
+        """restart() should not raise when the repl has no `.child` attribute."""
+        fake_engine = MagicMock()
+        fake_engine.repl = MagicMock(spec=["terminate"])
+        fake_engine.tmp_dir = tempfile.mkdtemp()
+        with patch("oct2py.core.OctaveEngine", return_value=fake_engine):
+            oc = Oct2Py()
+        assert oc._engine is fake_engine
+        oc.exit()
 
 
 class TestGetDoc:


### PR DESCRIPTION
## References

<!-- issue numbers -->
CI failure: `test (3.14t)` job on run [30259504522](https://github.com/blink1073/oct2py/actions/runs/30259504522/job/89956026163)

## Description

On the free-threaded (no-GIL) Python 3.14t build, `Oct2Py.exit()` (and
`restart()`) occasionally raised `pexpect.exceptions.ExceptionPexpect: Could
not terminate the child` during teardown, failing an otherwise fully-passing
test run (all 257 assertions passed; only the teardown step errored).

Root cause: `ptyprocess.PtyProcess.close()` closes the fd, sleeps
`delayafterclose` (default 0.1s), then checks `isalive()` before raising.
Under the free-threaded build, process reaping/signal delivery is apparently
racier, so `isalive()` can still report `True` immediately after the
termination signal was sent — a false "could not terminate", not an actual
leaked process.

## Changes

- Widen `delayafterclose`/`delayafterterminate` on the underlying pexpect
  child to 0.5s right after engine startup in `restart()`, giving the
  kernel more time to update process status before `isalive()` is checked.
- Add a `Oct2Py._terminate_repl()` helper used by both `exit()` and
  `restart()` that treats a stale-alive `ExceptionPexpect` from
  `repl.terminate()` as a non-fatal cleanup race (the signal was already
  sent) rather than a real failure, logging it at debug level instead.
  `restart()` hits the same call path when tearing down the previous
  engine, so it gets the same treatment for consistency.
- Add regression tests in `tests/test_core_branches.py` covering: `exit()`
  and `restart()` swallowing the stale-alive race, other exceptions from
  `terminate()` still propagating, the delay widening after `restart()`,
  and the no-op path when the repl has no `.child` attribute.

## Backwards-incompatible changes

None

## Testing

- `poetry run python -m pytest -n auto --dist=loadscope`: 263 passed, 8
  skipped, 2 xfailed.
- `just typing`: no issues.
- `just pre-commit`: all hooks pass.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code