### PR TITLE
Drop Test PyPI upload step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,6 @@ jobs:
           name: Packages
           path: dist
 
-      - name: Upload package to Test PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: ${{ github.event_name == 'schedule' || inputs.dry_run }}
-          verbose: ${{ github.event_name == 'schedule' || inputs.dry_run }}
-
       - name: Upload package to PyPI
         if: ${{ !(github.event_name == 'schedule' || inputs.dry_run) }}
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0


### PR DESCRIPTION
## Summary
- Removes the "Upload package to Test PyPI" step from `release.yml`. TestPyPI was a pre-publish smoke test that doesn't catch anything the existing static package checks (`twine check --strict` in the `build` job, `validate-pyproject` via pre-commit) don't already catch, and it's one more external service in the critical path of every release.
- The real "Upload package to PyPI" step is unchanged.

This is fix 1 of a 3-item CI/release hardening checklist based on changes made in calysto/metakernel#466. The other two items don't apply to this repo: static package checks (validate-pyproject, twine check --strict) already run on every PR/push via pre-commit and the `build` job, and the Codecov upload step here already uploads unconditionally (no fork-PR skip to remove).

## Test plan
- [x] `just pre-commit` (includes `actionlint` against the modified workflow) — passed
- [x] `just typing` — passed
- [x] `just test` — 263 passed, 8 skipped, 2 xfailed