### PR TITLE
Fix leaked Octave subprocesses in TestTerminateRepl

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -955,6 +955,8 @@ class Oct2Py:
     def restart(self):  # noqa: PLR0912, PLR0915
         """Restart an Octave session in a clean state"""
         if self._engine:
+            if callable(atexit.unregister):
+                atexit.unregister(self._engine._cleanup)
             self._terminate_repl()
 
         # Close any open writer file handle — its path is tied to the old

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -955,8 +955,7 @@ class Oct2Py:
     def restart(self):  # noqa: PLR0912, PLR0915
         """Restart an Octave session in a clean state"""
         if self._engine:
-            if callable(atexit.unregister):
-                atexit.unregister(self._engine._cleanup)
+            atexit.unregister(self._engine._cleanup)
             self._terminate_repl()
 
         # Close any open writer file handle — its path is tied to the old

--- a/tests/test_core_branches.py
+++ b/tests/test_core_branches.py
@@ -278,13 +278,31 @@ class TestEnterDel:
 class TestTerminateRepl:
     """Tests for the ExceptionPexpect-tolerant termination helper."""
 
+    @staticmethod
+    def _mock_terminate_after_real_call(repl, exc):
+        """Replace repl.terminate with a mock that still signals the real child.
+
+        Using a bare ``side_effect=exc`` would replace terminate() outright and
+        never send the OS signal, leaking the real Octave subprocess (it would
+        only die when the pytest process itself exits). Wrapping the real
+        method and raising *after* calling it exercises the same
+        exception-handling code path without leaking the process.
+        """
+        real_terminate = repl.terminate
+
+        def _raise_after_terminating(*args, **kwargs):
+            real_terminate(*args, **kwargs)
+            raise exc
+
+        repl.terminate = MagicMock(side_effect=_raise_after_terminating)
+
     def test_exit_swallows_stale_alive_race(self):
         """exit() should not raise when terminate() reports a stale-alive race."""
         from pexpect.exceptions import ExceptionPexpect
 
         oc = Oct2Py()
-        oc._engine.repl.terminate = MagicMock(
-            side_effect=ExceptionPexpect("Could not terminate the child.")
+        self._mock_terminate_after_real_call(
+            oc._engine.repl, ExceptionPexpect("Could not terminate the child.")
         )
         oc.exit()  # should not raise
         assert oc._engine is None
@@ -295,8 +313,8 @@ class TestTerminateRepl:
 
         oc = Oct2Py()
         old_engine = oc._engine
-        old_engine.repl.terminate = MagicMock(
-            side_effect=ExceptionPexpect("Could not terminate the child.")
+        self._mock_terminate_after_real_call(
+            old_engine.repl, ExceptionPexpect("Could not terminate the child.")
         )
         oc.restart()  # should not raise
         assert oc._engine is not old_engine
@@ -305,10 +323,10 @@ class TestTerminateRepl:
     def test_terminate_repl_reraises_other_exceptions(self):
         """Exceptions other than ExceptionPexpect should still propagate."""
         oc = Oct2Py()
-        oc._engine.repl.terminate = MagicMock(side_effect=RuntimeError("boom"))
+        self._mock_terminate_after_real_call(oc._engine.repl, RuntimeError("boom"))
         with pytest.raises(RuntimeError, match="boom"):
             oc._terminate_repl()
-        oc._engine.repl.terminate = MagicMock()  # avoid raising again during exit()
+        oc._engine.repl.terminate = MagicMock()  # already terminated; avoid raising again
         oc.exit()
 
 


### PR DESCRIPTION
## References

<!-- issue numbers -->
N/A

## Description

Three tests in `tests/test_core_branches.py::TestTerminateRepl` (added in #446) replaced `oc._engine.repl.terminate` with a plain `MagicMock` instead of wrapping the real method. Because the mock fully replaced `terminate()`, `exit()`/`restart()` never sent SIGHUP/SIGCONT/SIGINT to the real Octave OS process during those tests — `exit()` reported success (`oc._engine is None`) but the actual subprocess kept running, with no cleanup path at all (not even the `atexit`-registered `OctaveEngine._cleanup` fallback, since `exit()` unconditionally unregisters it before attempting termination). The process only died when the whole pytest process exited.

## Changes

- Reworked the three `TestTerminateRepl` mocks to wrap the real `terminate()` and raise only *after* actually invoking it, so the real OS signal is still sent while the same exception-tolerance code paths are still exercised.
- Added `atexit.unregister(self._engine._cleanup)` to `restart()` for the old engine, mirroring what `exit()` already does — closes a secondary, non-leaking bug where `restart()` left a dangling `atexit` registration and kept the old `OctaveEngine` object referenced for the rest of the process lifetime.

## Backwards-incompatible changes

None

## Testing

- Reproduced the leak directly before the fix (`ps -p <pid>` showed the Octave child still alive after `exit()` reported `oc._engine is None`).
- `poetry run python -m pytest tests/test_core_branches.py::TestTerminateRepl -v` — all 3 tests pass, confirmed via `ps aux | grep octave` that no process remains after the run.
- `just test` — 263 passed, 8 skipped, 2 xfailed; confirmed via `ps aux | grep octave` that no Octave process remains after the suite completes.
- `just typing` and `just pre-commit` — both clean.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code