### PR TITLE
chore: use extend-select for ruff rules

### DIFF
--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -856,7 +856,7 @@ class Oct2Py:
         prev_log_level = self.logger.level
 
         if kwargs.get("log") is False:
-            self.logger.setLevel(logging.WARN)
+            self.logger.setLevel(logging.WARNING)
 
         for name in ["log", "return_both"]:
             if name not in kwargs:

--- a/oct2py/dynamic.py
+++ b/oct2py/dynamic.py
@@ -100,7 +100,7 @@ class OctaveFunctionPtr(OctavePtr):
         ]
 
         extras = {}
-        for key, _ in kwargs.copy().items():
+        for key in kwargs.copy():
             if key not in allowed:
                 extras[key] = kwargs.pop(key)
 

--- a/oct2py/io.py
+++ b/oct2py/io.py
@@ -19,12 +19,8 @@ except Exception:  # pragma: no cover
     class Series:  # type:ignore[no-redef]
         """placeholder."""
 
-        pass
-
     class DataFrame:  # type:ignore[no-redef]
         """placeholder."""
-
-        pass
 
 
 from .dynamic import OctaveFunctionPtr, OctaveUserClass, OctaveVariablePtr

--- a/oct2py/utils.py
+++ b/oct2py/utils.py
@@ -12,13 +12,9 @@ import sys
 class Oct2PyError(Exception):
     """Called when we can't open Octave or Octave throws an error"""
 
-    pass
-
 
 class Oct2PyWarning(UserWarning):
     """Warning raised by oct2py for deprecations and other advisory conditions."""
-
-    pass
 
 
 def get_log(name=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,10 +137,12 @@ ignore_missing_imports = true
 line-length = 100
 
 [tool.ruff.lint]
-select = [
-  "A", "B", "C", "DTZ", "E", "EM", "F", "FBT", "I", "ICN", "N",
+# DTZ and YTT are omitted below since ruff 0.16's default rule set already
+# enables them in full; extend-select only needs to add what defaults miss.
+extend-select = [
+  "A", "B", "C", "E", "EM", "F", "FBT", "I", "ICN", "N",
   "PLC", "PLE", "PLR", "PLW", "Q", "RUF", "S", "SIM", "T", "TID", "UP",
-  "W", "YTT",
+  "W",
 ]
 external = [
   "DOC",  # pydoclint
@@ -155,7 +157,13 @@ ignore = [
 # C408 Unnecessary `dict` call (rewrite as a literal)
 "C408", "C409",
 # Unnecessary upgrades
-"UP031"
+"UP031",
+# BLE001 Do not catch blind exception - used intentionally for optional
+# imports and best-effort subprocess/session cleanup throughout the codebase
+"BLE001",
+# TRY002 Create your own exception - single occurrence, needs a design
+# decision on a dedicated exception type
+"TRY002",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## References

<!-- issue numbers -->
N/A

## Description

Ruff 0.16 significantly expanded its default rule set (it now enables specific rules from many more categories than just `E4`/`E7`/`E9`/`F`, per the [default rules docs](https://docs.astral.sh/ruff/rules/)). Our `[tool.ruff.lint]` config used `select`, which fully replaces the default rule set rather than building on it — so we were silently missing out on rules ruff considers default-worthy.

## Changes

- Switch `tool.ruff.lint.select` to `extend-select` so our config adds to ruff's defaults instead of replacing them.
- Drop `DTZ` and `YTT` from the list — verified via `ruff check --show-settings --isolated` that ruff 0.16 already enables every rule in both categories by default, so listing them was redundant.
- Fix the new violations `extend-select` surfaced now that previously-unselected default categories are active:
  - `LOG009`: `logging.WARN` → `logging.WARNING`
  - `PERF102`/`SIM118`: simplify a keys-only dict iteration
  - `PIE790` (×4): remove dead `pass` statements after docstrings
- Add `BLE001` and `TRY002` to `ignore` for now, with rationale comments:
  - `BLE001` (blind `except Exception`) is used intentionally throughout for optional-import fallback and best-effort subprocess/session cleanup.
  - `TRY002` (raise vanilla `Exception`) has a single occurrence that would need a dedicated exception type — a separate design decision.

## Backwards-incompatible changes

None

## Testing

Verified with `ruff check`/`ruff format` (pinned to the `v0.16.0` version used by pre-commit), plus `just typing` and `just pre-commit` — all pass.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code