### PR TITLE
Standardize justfile targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,12 @@ To run linters:
 just lint
 ```
 
+To also run manual-stage hooks (such as `markdown-link-check`):
+
+```
+just lint-all
+```
+
 To run type checking:
 
 ```

--- a/justfile
+++ b/justfile
@@ -4,82 +4,77 @@ default:
 
 # Install the project with all development dependencies
 install:
-    poetry install --with test,dev
+    poetry sync --only main,test,dev
     poetry run pre-commit install
 
 # Run tests
 test *args:
-    poetry install --with test
+    poetry sync --only main,test
     poetry run python -m pytest -n auto --dist=loadscope -vv {{args}}
 
 # Run tests sequentially (no xdist) — mirrors the sdist test environment
 test-seq *args:
-    poetry install --with test
+    poetry sync --only main,test
     poetry run python -m pytest -v {{args}}
 
 # Run tests with coverage
 cover *args:
-    poetry install --with cover
+    poetry sync --only main,cover
     poetry run python -m pytest -n auto --dist=loadscope --doctest-modules -l --cov-report html --cov-report=xml --cov-report=term-missing --cov=oct2py --cov-fail-under 85 -vv {{args}}
 
-# Run linters (ruff check + format)
-lint:
-    poetry install --with dev
-    just pre-commit ruff-format
-    just pre-commit ruff-check
-    just pre-commit interrogate
-    just pre-commit doc8
-    just pre-commit validate-pyproject
-    just pre-commit poetry-check
+# Run all pre-commit hooks
+lint *args:
+    poetry sync --only main,dev
+    poetry run pre-commit run --all-files {{args}}
 
 # Run type checking (mypy)
 typing:
-    poetry install --with typing
+    poetry sync --only main,typing
     poetry run mypy --install-types --non-interactive oct2py
 
 # Build documentation
 docs:
-    poetry install --with docs
+    poetry sync --only main,docs
     poetry run mkdocs build --strict
 
 # Serve documentation locally
 docs-serve:
-    poetry install --with docs
+    poetry sync --only main,docs
     poetry run mkdocs serve
 
 # Open the example notebook interactively
 run-notebook:
-    poetry install --with test
+    poetry sync --only main,test
     poetry run jupyter notebook example/octavemagic_extension.ipynb
 
 # Run the example notebook as a test
 test-notebook:
-    poetry install --with test
+    poetry sync --only main,test
     poetry run jupyter nbconvert --to notebook --execute --stdout example/octavemagic_extension.ipynb > /dev/null
 
 # Run ASV benchmarks on HEAD (quick mode: one run per benchmark, ≤5 min)
 benchmark:
-    poetry install --with bench
+    poetry sync --only main,bench
     poetry run asv run --quick HEAD^!
 
 # Compare benchmarks between the branch base commit and HEAD
 benchmark-compare:
-    poetry install --with bench
+    poetry sync --only main,bench
     poetry run asv machine --yes
     poetry run asv continuous $(git merge-base HEAD origin/main) HEAD --show-stderr
 
 # Test opencv/oct2py compatibility
 test-opencv:
-    poetry install
+    poetry sync --only main
     poetry run pip install opencv-python
     poetry run python scripts/test-opencv.py
 
 # Build and run the PyInstaller test app
 pyinstaller-test:
-    poetry install --with pyinstaller
+    poetry sync --only main,pyinstaller
     poetry run python pyinstaller_test/test_build.py
 
-# Run a pre-commit target
-pre-commit *args:
-    poetry install --with dev
-    poetry run pre-commit run --all-files {{args}}
+# Run all pre-commit hooks, including manual-stage hooks
+lint-all *args:
+    poetry sync --only main,dev
+    poetry run pre-commit run --all-files --hook-stage manual {{args}}


### PR DESCRIPTION
## References

None

## Description

The five developer commands now mean the same thing across the Calysto repos and here: `install`, `test`, `cover`, `typing`, and `lint`.

Two things were confusing before. `lint` ran a hand-picked subset of pre-commit hooks while a separate `pre-commit` recipe ran all of them, so neither name described what it did. Recipes also did not control their own environment, so running one target could leave dependencies in a state the next target did not expect. Each recipe now syncs the exact dependency groups it needs, which makes any order of commands safe.

## Changes

- Renamed the run-all-hooks recipe from `pre-commit` to `lint`
- Added `lint-all` for hooks that only run at the manual stage, such as `markdown-link-check`
- Every recipe syncs the dependency groups it needs before doing its work, replacing the previous additive installs
- Normalized the justfile to LF line endings
- Updated the contributing guide to match

## Backwards-incompatible changes

`just pre-commit` no longer exists. Use `just lint`, or `just lint-all` to include the manual-stage hooks.

## Testing

- `just lint` passes
- `just typing` passes with no issues in 13 source files
- `just test` passes, 263 tests with 8 skipped and 2 xfailed

The line ending change touches every line of the justfile. To review only the substantive changes, use `git diff --ignore-cr-at-eol`.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
