### PR TITLE
Stop leaking Octave processes when a session fails to start

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Line endings are mixed throughout this repository's history. Storing files
+# byte for byte keeps git from renormalizing whole files into a diff.
+* -text
+
+# Pinned instead: a stray CRLF save rewrote the whole file in #455.
+justfile text eol=lf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
         with:
           python-version: ${{ matrix.python-version }}
@@ -55,6 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
         with:
           python-version: "3.11"
@@ -66,7 +70,8 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt-get install -qq octave-signal
       - name: Generate coverage report
-        run: ${{ startsWith(matrix.os, 'ubuntu') && 'just cover' || 'just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py' }}
+        # test_core_branches.py covers the pexpect startup and teardown paths.
+        run: ${{ startsWith(matrix.os, 'ubuntu') && 'just cover' || 'just cover tests/test_usage.py tests/test_misc.py tests/test_octavemagic.py tests/test_core_branches.py' }}
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
@@ -91,6 +96,8 @@ jobs:
       POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Install Octave
         uses: calysto/octave_action@v1
@@ -142,6 +149,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - run: just docs
 
@@ -159,6 +168,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - run: just typing
 
@@ -200,6 +211,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
+    env:
+      # The bundled app never plots, so it can skip the slower GUI binary.
+      # Jobs that do plot must not set this: octave-cli has no qt toolkit.
+      OCTAVE_EXECUTABLE: octave-cli
     steps:
       - uses: actions/checkout@v4
         with:

--- a/oct2py/core.py
+++ b/oct2py/core.py
@@ -1028,6 +1028,8 @@ class Oct2Py:
                 _child.delayafterclose = 0.5
                 _child.delayafterterminate = 0.5
         except Exception as e:
+            # Any process the engine already spawned is terminated upstream;
+            # see the floors in pyproject.toml.
             raise Oct2PyError(str(e)) from None
         finally:
             if _saved_sigint is not None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3135,7 +3135,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "cover", "dev", "docs", "test", "typing", "typing-extra"]
+groups = ["main", "cover", "cover-extra", "dev", "docs", "test", "typing", "typing-extra"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -3260,24 +3260,25 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["cover", "cover-extra", "dev", "test", "typing"]
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
@@ -4236,4 +4237,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "7cf28e5f6ac9871c800232abcc17077a460c6f41feb96c5c42d28898f5381287"
+content-hash = "38a41fafc5445a76235d102ea82bbfa9ad3456a0b1f77a4b446887e2e5c891dd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1934,14 +1934,14 @@ files = [
 
 [[package]]
 name = "metakernel"
-version = "1.0.0"
+version = "1.0.6"
 description = "A Jupyter/IPython Kernel base class in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "metakernel-1.0.0-py3-none-any.whl", hash = "sha256:9f90660ce583baffe0235316f3e1a0abf75bbf60039e811ccbedd68ef612fa44"},
-    {file = "metakernel-1.0.0.tar.gz", hash = "sha256:76f2b8926cbad5a089deb6f727399c4e34e8915af97896a8bb7968ebe02da21c"},
+    {file = "metakernel-1.0.6-py3-none-any.whl", hash = "sha256:98844d70e015890ea3d3a9f8f67e3a799861609f0cace4cec986e1a3d6a7f36e"},
+    {file = "metakernel-1.0.6.tar.gz", hash = "sha256:09f898f50d037f1e69ca180f4238d330989c407f9c424808fc333592e6367883"},
 ]
 
 [package.dependencies]
@@ -2489,20 +2489,20 @@ files = [
 
 [[package]]
 name = "octave-kernel"
-version = "1.1.0"
+version = "1.1.1"
 description = "'A Jupyter kernel for Octave.'"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "octave_kernel-1.1.0-py3-none-any.whl", hash = "sha256:d08dd22d6a5907f48e1ddd81d726c8b487f86b358c9c7023b0d08dfc723488af"},
-    {file = "octave_kernel-1.1.0.tar.gz", hash = "sha256:2c6e907a126b2d1c9b37900460bf8c66442e7aea9071aaa7c4b4834d39554961"},
+    {file = "octave_kernel-1.1.1-py3-none-any.whl", hash = "sha256:1bf64b278659d1d082744c9c8d9fe8eb010ff798c8378f0924c9f311e4b9571c"},
+    {file = "octave_kernel-1.1.1.tar.gz", hash = "sha256:8c9821bf32dde6b3aae9b09c5663e035f0987530245257c7d31e3fcf0086195f"},
 ]
 
 [package.dependencies]
 ipykernel = ">=6.22.0"
 jupyter-client = ">=8.1.0"
-metakernel = ">=1.0"
+metakernel = ">=1.0.6"
 rpds-py = ">=2026.5.1"
 
 [[package]]
@@ -4236,4 +4236,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "c65b6beef8b52babfdc221604e4239fb869ab83cae7e6a8b70b515548777aa87"
+content-hash = "7cf28e5f6ac9871c800232abcc17077a460c6f41feb96c5c42d28898f5381287"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [{ include-group = "test" }, { include-group = "dev-extra" }]
 typing-extra = ["mypy>=1.15", "ipython>=9.0", "pip"]
 typing = [{ include-group = "test" }, { include-group = "typing-extra" }]
 test = [
-    "pytest<8",
+    "pytest>=9.0.3",
     "pytest-xdist",
     "flaky",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy >=1.25.0",
     "scipy >=1.17.1",
-    "octave-kernel>=1.0",
+    # These floors terminate the Octave process when startup fails.
+    "octave-kernel>=1.1.1",
+    "metakernel>=1.0.6",  # imported directly by core.py
     "pydantic-settings>=2.0",
     "tornado>=6.5.5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ addopts = [
    "--import-mode=importlib"
 ]
 testpaths = ["tests", "tests/ipython"]
+markers = [
+  "needs_octave_gui: needs the GUI-linked `octave` binary; octave-cli lacks the qt graphics toolkit",
+]
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL"
 timeout = 300
 # Restore this setting to debug failures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared pytest configuration for the oct2py test suite."""
+
+import os
+import shutil
+import sys
+
+import pytest
+
+# `octave` launches the Qt-linked GUI binary even with --no-gui: slower to
+# start, and on a cold Windows runner it has stalled past pexpect's 30s wait
+# for the first prompt. Linux keeps it, since octave-cli is built without the
+# GUI libraries and inline plotting fails without the qt graphics toolkit.
+#
+# Set at import time, before the test modules import oct2py: that import builds
+# the module-level session, one per xdist worker, for the whole run.
+_OCTAVE_CLI = None if sys.platform.startswith("linux") else shutil.which("octave-cli")
+
+# True when this suite owns the value: unset, or already the path set here in
+# the parent, which xdist workers inherit. Anything else is a deliberate choice
+# from the environment and wins; the flatpak and snap CI jobs rely on that.
+_APPLIED = bool(_OCTAVE_CLI) and os.environ.get("OCTAVE_EXECUTABLE") in (None, _OCTAVE_CLI)
+if _APPLIED:
+    os.environ["OCTAVE_EXECUTABLE"] = _OCTAVE_CLI  # type:ignore[assignment]
+
+
+@pytest.fixture(scope="session")
+def gui_octave():
+    """A session on the GUI-linked `octave`, for tests that render figures.
+
+    Shared, so leave the workspace as you found it and do not exit it.  An
+    empty executable leaves oct2py to resolve one as it normally would, which
+    is what the flatpak and snap jobs need.
+    """
+    from oct2py import Oct2Py
+
+    # Deliberately not offscreen: these tests render figures to files, and
+    # QT_QPA_PLATFORM=offscreen makes Octave write an empty image.  A test that
+    # opens a real figure window needs the opposite and builds its own session.
+    oc = Oct2Py(executable=shutil.which("octave") or "")
+    yield oc
+    oc.exit()
+
+
+@pytest.fixture(autouse=True)
+def _octave_executable(request, monkeypatch):
+    """Hand the GUI-linked `octave` back to a test that cannot ask for it.
+
+    For tests whose session is built out of reach, so `gui_octave` cannot be
+    used.  Only covers sessions created during the test: class fixtures run
+    first, so a ``setup_class`` session still gets octave-cli.
+    """
+    if _APPLIED and request.node.get_closest_marker("needs_octave_gui"):
+        monkeypatch.delenv("OCTAVE_EXECUTABLE", raising=False)

--- a/tests/ipython/test_octavemagic.py
+++ b/tests/ipython/test_octavemagic.py
@@ -1,6 +1,8 @@
 """Tests for Octave magics extension."""
 
 import codecs
+import os
+import shutil
 import sys
 import unittest
 from typing import Any
@@ -9,6 +11,7 @@ import numpy as np
 from IPython.display import SVG
 from IPython.testing.globalipapp import get_ipython
 
+import oct2py
 from oct2py import Oct2PyError
 
 
@@ -28,8 +31,23 @@ class OctaveMagicTest(unittest.TestCase):
         # This is just to get a minimally modified version of the changes
         # working
         cls.ip.run_line_magic("load_ext", "oct2py.ipython")
+        # Inline figures need the qt toolkit that octave-cli lacks. Setting
+        # the trait also rewrites OCTAVE_EXECUTABLE, hence the restore below.
+        cls._saved_executable = os.environ.get("OCTAVE_EXECUTABLE")  # type:ignore[attr-defined]
+        gui_octave = shutil.which("octave")
+        if cls._saved_executable and gui_octave:  # type:ignore[attr-defined]
+            cls.ip.find_cell_magic("octave").__self__.executable = gui_octave
         cls.ip.ex("import numpy as np")
         cls.svgs_generated = 0  # type:ignore[attr-defined]
+
+    @classmethod
+    def tearDownClass(cls):
+        """Close the magic's session and restore the suite's executable."""
+        magic = cls.ip.find_cell_magic("octave").__self__
+        if magic._oct is not oct2py.octave:
+            magic._oct.exit()
+        if cls._saved_executable is not None:  # type:ignore[attr-defined]
+            os.environ["OCTAVE_EXECUTABLE"] = cls._saved_executable  # type:ignore[attr-defined]
 
     def test_octave_inline(self):
         result = self.ip.run_line_magic("octave", "[1, 2, 3] + 1;")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -195,6 +195,7 @@ class TestMisc:
         assert not any(issubclass(w.category, Oct2PyWarning) for w in caught)
         assert any(w.category is UserWarning for w in caught)
 
+    @pytest.mark.needs_octave_gui
     def test_demo(self):
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")
@@ -213,6 +214,9 @@ class TestMisc:
         except TypeError:
             thread_check.thread_check()  # type:ignore[attr-defined]
 
+    # Six concurrent startups on a cold Windows runner can exceed pexpect's
+    # 30s startup wait, failing the session rather than the leak check.
+    @flaky(rerun_filter=lambda *_: sys.platform == "win32")
     def test_threadpool_no_process_leak(self):
         """Oct2Py sessions created in a ThreadPoolExecutor must not leak Octave
         subprocesses after the threads complete (issue #289)."""
@@ -282,13 +286,13 @@ class TestMisc:
         assert "Octave exe:" in out
         assert "Connection OK" in out
 
-    def test_plot(self):
+    def test_plot(self, gui_octave):
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")
-        plot_dir = tempfile.mkdtemp(dir=self.oc.settings.temp_dir).replace("\\", "/")
-        self.oc.plot([1, 2, 3], plot_dir=plot_dir)
+        plot_dir = tempfile.mkdtemp(dir=gui_octave.settings.temp_dir).replace("\\", "/")
+        gui_octave.plot([1, 2, 3], plot_dir=plot_dir)
         assert glob.glob("%s/*" % plot_dir)
-        assert self.oc.extract_figures(plot_dir)
+        assert gui_octave.extract_figures(plot_dir)
 
     @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
     def test_plot_via_eval(self):
@@ -308,7 +312,7 @@ class TestMisc:
         assert glob.glob("%s/*" % plot_dir), "No figure files saved from eval() plot"
         assert self.oc.extract_figures(plot_dir), "extract_figures returned nothing"
 
-    def test_plot_from_inside_m_file(self):
+    def test_plot_from_inside_m_file(self, gui_octave):
         """Test that plots generated inside a .m function are captured via plot_dir (issue #172).
 
         When a .m file creates figures internally (e.g. clf/subplot/plot/pause),
@@ -317,8 +321,8 @@ class TestMisc:
         """
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")
-        plot_dir = tempfile.mkdtemp(dir=self.oc.settings.temp_dir).replace("\\", "/")
-        m_path = os.path.join(self.oc.settings.temp_dir, "test_plot_inside.m")
+        plot_dir = tempfile.mkdtemp(dir=gui_octave.settings.temp_dir).replace("\\", "/")
+        m_path = os.path.join(gui_octave.settings.temp_dir, "test_plot_inside.m")
         with open(m_path, "w") as f:
             f.write(
                 "function test_plot_inside()\n"
@@ -330,12 +334,13 @@ class TestMisc:
                 "end\n"
             )
         try:
-            self.oc.feval(m_path, nout=0, plot_dir=plot_dir)
+            gui_octave.feval(m_path, nout=0, plot_dir=plot_dir)
             assert glob.glob("%s/*" % plot_dir), "No figure files saved from inside .m function"
-            assert self.oc.extract_figures(plot_dir), "extract_figures returned nothing"
+            assert gui_octave.extract_figures(plot_dir), "extract_figures returned nothing"
         finally:
             os.unlink(m_path)
 
+    @pytest.mark.needs_octave_gui
     def test_interactive_figure(self, monkeypatch):
         """Test that figures created via eval() are accessible (issues #176, #158).
 
@@ -347,23 +352,27 @@ class TestMisc:
         """
         if self._flatpak:
             pytest.skip("not supported inside flatpak sandbox")
+        # Its own session, not the shared `gui_octave` one: opening a real
+        # figure window segfaults on macOS CI without an offscreen platform,
+        # and offscreen makes the file-rendering tests write empty images.
         if sys.platform == "darwin" and os.environ.get("CI"):
-            # macOS CI runners have no interactive window server, so Octave's
-            # "qt" toolkit segfaults creating a real figure window here.
             monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
-        oc = Oct2Py(backend="default")
-        oc.figure(1)
-        n_figs = oc.eval("numel(get(0, 'children'))", nout=1)
-        assert int(n_figs) >= 1, "Expected at least one open figure after figure(1)"
+        oc = Oct2Py()
+        try:
+            oc.figure(1)
+            n_figs = oc.eval("numel(get(0, 'children'))", nout=1)
+            assert int(n_figs) >= 1, "Expected at least one open figure after figure(1)"
 
-        # Verify that a plot created via eval() also registers as a figure (issue #158).
-        oc.eval("figure(2); plot([1, 2, 3]);")
-        n_figs_after = oc.eval("numel(get(0, 'children'))", nout=1)
-        assert int(n_figs_after) >= 2, "Expected at least two open figures after eval('plot(...)')"
+            # A plot created via eval() must register as a figure too (issue #158).
+            oc.eval("figure(2); plot([1, 2, 3]);")
+            n_figs_after = oc.eval("numel(get(0, 'children'))", nout=1)
+            assert int(n_figs_after) >= 2, "Expected two open figures after eval('plot(...)')"
 
-        oc.eval("close all")
-        oc.exit()
+            oc.eval("close all")
+        finally:
+            oc.exit()
 
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
     def test_show(self):
         """Test _show_figures() end-to-end using matplotlib's inline backend (issue #164).
 


### PR DESCRIPTION
## References

Diagnosed from nightly run 31916428695. Upstream halves: Calysto/metakernel#475 (first published in 1.0.6) and Calysto/octave_kernel#363 (1.1.1). Also closes the pytest Dependabot alert, GHSA-6w46-j5rx-g56g.

## Description

`cover (windows-latest)` failed on `test_threadpool_no_process_leak`: it starts three sessions at once, one never sent a prompt, and pexpect timed out after its default 30s. The job ended with an orphaned `octave`/`octave-gui` pair, because a session that fails to start was owned by nobody. Both upstreams now terminate their own child, so this requires the releases that do.

`octave` is also the expensive way to start a session. It launches the Qt-linked GUI binary even with `--no-gui`, and leaves one process per xdist worker alive for the whole run because the module-level session is built at import. Windows and macOS now use octave-cli; Linux keeps `octave`, since octave-cli has no qt graphics toolkit.

The coverage banner in that log was cosmetic rather than the failure: pytest-cov compares the rounded value, and green runs printed the same line at 84.66%.

## Changes

- Requires metakernel 1.0.6 and octave_kernel 1.1.1, which terminate the Octave process when startup fails. metakernel is declared directly because `core.py` imports `metakernel.pexpect`.
- Windows and macOS run against octave-cli, set from conftest import time so the module-level sessions are covered. Figure tests share a session-scoped `gui_octave` fixture on the GUI binary; `test_interactive_figure` and `test_demo` keep their own, one needing an offscreen Qt platform and the other building its session out of reach.
- The threadpool leak test retries on Windows, where six concurrent startups on a cold runner can still exceed the startup timeout.
- The cover job off Linux also runs `test_core_branches.py`, covering the pexpect startup and teardown paths.
- Drops the `pytest<8` pin, which predates the fix for GHSA-6w46-j5rx-g56g. The floor is 9.0.3 with no upper bound.
- The PyInstaller app uses octave-cli, since it never plots, and `persist-credentials: false` on the checkout steps missing it.
- A `.gitattributes` storing files byte for byte and pinning the justfile to LF, so a stray save cannot rewrite a whole file again as in #455.

## Backwards-incompatible changes

None for callers. The dependency floors move up, which is what makes the fix effective.

## Testing

`just test` (262 passed, 9 skipped, 2 xfailed), `just lint` and `just typing`, clean on pytest 9.1.1, and again under `CI=1` so the macOS-only offscreen path runs locally.

The cover job's file list off Linux measures 86.09%, up from 84.92%, so the gate has margin instead of depending on rounding. On macOS the suite went from 84s to 48s, and Octave processes alive for most of the run from ten to one.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
