### PR TITLE
Let Python 3.15 install pyinstaller

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,6 +210,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.11"]
+        # Bundling breaks on python internals, so cover the newest version too.
+        include:
+          - os: ubuntu-latest
+            python-version: "3.15"
       fail-fast: false
     env:
       # The bundled app never plots, so it can skip the slower GUI binary.
@@ -221,7 +226,7 @@ jobs:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: Install Octave
         uses: calysto/octave_action@v1
         with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ description = "Python graph (network) package"
 optional = false
 python-versions = "*"
 groups = ["pyinstaller"]
-markers = "python_version <= \"3.14\""
+markers = "python_version < \"3.16\""
 files = [
     {file = "altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597"},
     {file = "altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7"},
@@ -1734,7 +1734,7 @@ description = "Mach-O header analysis and editing"
 optional = false
 python-versions = "*"
 groups = ["pyinstaller"]
-markers = "python_version <= \"3.14\" and sys_platform == \"darwin\""
+markers = "python_version < \"3.16\" and sys_platform == \"darwin\""
 files = [
     {file = "macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea"},
     {file = "macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362"},
@@ -2602,7 +2602,7 @@ files = [
     {file = "packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"},
     {file = "packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79"},
 ]
-markers = {pyinstaller = "python_version <= \"3.14\""}
+markers = {pyinstaller = "python_version < \"3.16\""}
 
 [[package]]
 name = "paginate"
@@ -2758,7 +2758,7 @@ description = "Python PE parsing module"
 optional = false
 python-versions = ">=3.6.0"
 groups = ["pyinstaller"]
-markers = "python_version <= \"3.14\" and sys_platform == \"win32\""
+markers = "python_version < \"3.16\" and sys_platform == \"win32\""
 files = [
     {file = "pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f"},
     {file = "pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632"},
@@ -3237,7 +3237,7 @@ description = "PyInstaller bundles a Python application and all its dependencies
 optional = false
 python-versions = "<3.16,>=3.8"
 groups = ["pyinstaller"]
-markers = "python_version <= \"3.14\""
+markers = "python_version < \"3.16\""
 files = [
     {file = "pyinstaller-6.22.2-py3-none-macosx_10_13_universal2.whl", hash = "sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d"},
     {file = "pyinstaller-6.22.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c"},
@@ -3273,7 +3273,7 @@ description = "Community maintained hooks for PyInstaller"
 optional = false
 python-versions = ">=3.8"
 groups = ["pyinstaller"]
-markers = "python_version <= \"3.14\""
+markers = "python_version < \"3.16\""
 files = [
     {file = "pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3"},
     {file = "pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725"},
@@ -3506,7 +3506,7 @@ description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
 optional = false
 python-versions = ">=3.6"
 groups = ["pyinstaller"]
-markers = "python_version <= \"3.14\" and sys_platform == \"win32\""
+markers = "python_version < \"3.16\" and sys_platform == \"win32\""
 files = [
     {file = "pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"},
     {file = "pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"},
@@ -4042,7 +4042,7 @@ description = "Most extensible Python build backend with support for C/C++ exten
 optional = false
 python-versions = ">=3.10"
 groups = ["pyinstaller"]
-markers = "python_version <= \"3.14\""
+markers = "python_version < \"3.16\""
 files = [
     {file = "setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670"},
     {file = "setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73"},
@@ -4341,4 +4341,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "38a41fafc5445a76235d102ea82bbfa9ad3456a0b1f77a4b446887e2e5c891dd"
+content-hash = "51604d457daf73c6bb7564b77b58ccac0024474b02580330af7b853b82af8e9d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ bench = [
     "virtualenv",
 ]
 pyinstaller = [
-    "pyinstaller>=6.15; python_version < '3.15'",
+    # Every pyinstaller release caps its own python range, so this needs an upper bound to stay solvable.
+    "pyinstaller>=6.15; python_version < '3.16'",
 ]
 
 


### PR DESCRIPTION
## References

Follow-up to #435.

## Description

PyInstaller was excluded on Python 3.15 while it had no release supporting that version. 6.21 raised its ceiling to `<3.16`, so the exclusion is obsolete and 3.15 users can bundle again.

The marker cannot be dropped entirely. Every PyInstaller release caps its own Python range, and `oct2py`'s `requires-python` has no upper bound, so without a ceiling Poetry has to satisfy PyInstaller on 3.16+ and fails to resolve.

## Changes

- Allowed PyInstaller on Python 3.15 by moving its marker ceiling to `<3.16`.
- Added an ubuntu 3.15 run to the PyInstaller job so bundling is exercised there, not just resolved.

## Backwards-incompatible changes

None

## Testing

`poetry lock` resolves; PyInstaller 6.22.2 locks under `python_version < "3.16"`, which covers 3.15. The PyInstaller job previously pinned 3.11, so CI now adds a 3.15 run on ubuntu.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
